### PR TITLE
Issuance sample update

### DIFF
--- a/sample/issuer/Cargo.toml
+++ b/sample/issuer/Cargo.toml
@@ -5,11 +5,9 @@ edition = "2021"
 default-run = "crescent-sample-issuer"
 
 [dependencies]
-rocket = { version = "0.5.1", features = ["json"] }
+rocket = { version = "0.5.1", features = ["json", "tls"] }
+rocket_dyn_templates = { version = "0.1.0", features = ["tera"] }
 serde = { version = "1.0", features = ["derive"] }
 jsonwebtoken = "9.1"
-chrono = "0.4"
-pem = "0.8"
-rsa = "0.6"
-base64 = "0.21"
+chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"

--- a/sample/issuer/README.md
+++ b/sample/issuer/README.md
@@ -10,9 +10,6 @@ TODO: document how to add demo users
 
 ## Running the server
 
-To start the server, run `cargo run`.
+To start the server, run `cargo run`. By default, the server will listen on `http://localhost:8001`; this can be modified by changing the `port` variable in the [Rocket.toml](./Rocket.toml) file.
 
-You can test the server is working correctly by requesting a JWT using curl:
-```
-curl -X POST http://localhost:8000/issue -H "Content-Type: application/json" -d '{"username": "admin", "password": "password"}'
-```
+You can test the server is working correctly by visiting `http://localhost:8001/welcome` and entering the username `alice` and password `password`.

--- a/sample/issuer/Rocket.toml
+++ b/sample/issuer/Rocket.toml
@@ -1,0 +1,2 @@
+[default]
+port = 8001

--- a/sample/issuer/templates/login.html.tera
+++ b/sample/issuer/templates/login.html.tera
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    {% if error %}
+        <p style="color: red;">{{ error }}</p>
+    {% endif %}
+    <form action="/login" method="post">
+        <label for="username">Username:</label>
+        <input type="text" name="username" id="username" required />
+        <br />
+        <label for="password">Password:</label>
+        <input type="password" name="password" id="password" required />
+        <br />
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>

--- a/sample/issuer/templates/welcome.html.tera
+++ b/sample/issuer/templates/welcome.html.tera
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome</title>
+</head>
+<body>
+    <h1>Welcome, {{ username }}!</h1>
+    <p>Click the "Issue" button below to get an employment JSON Web Token.</p>
+    <form action="/issue" method="post">
+        <button type="submit">Issue</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
Small refactor of the sample issuer. Changes:
* Changed demo users' domain from `microsoft.com` to `example.com`
* Added login and welcome HTML pages to interact with server using a web browser.
* Updated README.md.

A browser extension can now pick up the issued JWT from the `jwt` textarea from the returned HTML page.