### PR TITLE
Update readmes with windows specific info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Crescent
 
 Crescent is a library to generate proofs of possession of JSON Web Tokens (JWT) and
-mobile Driver's Licenses (mDL) credentials. 
+mobile Driver's Licenses (mDL) credentials.
 By creating a proof for a JWT or mDL, rather than sending it directly, the credential holder may choose
 to keep some of the claims in the credential private, while still providing the verifier with assurance
 that the revealed claims are correct and that the underlying credential is still valid.
@@ -10,38 +10,62 @@ This repository contains the Crescent library and a sample application consistin
 a setup service, a browser extension client and client helper service, and a web server verifier. some
 external dependencies have been forked into this project; see the [NOTICE](./NOTICE.md) file for details
 
-*Disclaimer: This code has not beeen carefully audited for security and should not be used in a production environment.*
+*Disclaimer: This code has not been carefully audited for security and should not be used in a production environment.*
 
 # Setting up
+
+### Windows: Enable symlinks with git
+
+This project uses symlinks to share directories within the project. On Windows, symlinks require administrator privileges. Git can be configured to create project symlinks when cloning the repository.
+To enable symlinks with git, run the following command:
+
+```bash
+git config --global core.symlinks true
+```
+
+If you have already cloned the repository, you can delete and re-clone the repository for the symlinks to be created or manually create the link by running the following CMD command in the project root directory:
+
+```cmd
+mklink /J circuit_setup\circuits-mdl\circomlib circuit_setup\circuits\circomlib
+```
+
+Verify `circuit_setup\circuits-mdl\circomlib` is now a directory.
+
 To setup the library, see the instructions in [`/circuit_setup/README.md`](./circuit_setup/README.md);
 to setup the sample application, see [`sample/README.md`](./sample/README.md).
 
 To check that the library has been setup correctly, run
-```
+
+```bash
 cd creds
 cargo test --release
 ```
 
 # Running the demo steps from the command line
-There is a command line tool that can be used to run the individual parts of the demo separately.  This clearly separates the roles of prover and verifier, and shows what parameters are required by each.  The filesystem is used to store data between steps, and also to "communicate" show proofs from prover to verifier. 
+
+There is a command line tool that can be used to run the individual parts of the demo separately.  This clearly separates the roles of prover and verifier, and shows what parameters are required by each.  The filesystem is used to store data between steps, and also to "communicate" show proofs from prover to verifier.
 
 The circuit setup must be completed first, by running
-```
+
+```bash
 cd circuit_setup/scripts
 ./run_setup.sh rs256
 ./run_setup.sh mdl1
 cd ../../creds
 ```
+
 Circuit setup will copy data (parameters etc.) into `creds/test-vectors/`.
 
 The individual steps are
-* `zksetup` Generates the (circuit-specific) system parameters 
+
+* `zksetup` Generates the (circuit-specific) system parameters
 * `prove` Generates the Groth16 proof for a credential.  Stored for future presentation proofs in the "client state"
 * `show` Creates a fresh and unlinkable presentation proof to be sent to the verifier
 * `verify` Checks that the show proof is valid
 
 and we can run each step as follows
-```
+
+```bash
 cargo run --bin crescent --release --features print-trace zksetup --name rs256
 cargo run --bin crescent --release --features print-trace prove --name rs256
 cargo run --bin crescent --release --features print-trace show --name rs256
@@ -56,7 +80,7 @@ Note that the steps have to be run in order, but once the client state is create
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -68,8 +92,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/circuit_setup/README.md
+++ b/circuit_setup/README.md
@@ -1,39 +1,41 @@
 
 # Crescent Setup
 
-
 The setup part of the project is built with a few main dependencies
 
 - [Circom](https://github.com/iden3/circom) used as a front end to describe circuits,
 - [Circomlib](https://github.com/iden3/circomlib) provides gadgets
 
-
 and we acknowledge Circom circuits we used from
-- [Zkemail](https://github.com/zkemail/zk-email-verify/tree/main) 
 
+- [Zkemail](https://github.com/zkemail/zk-email-verify/tree/main)
 
 ## Installing Dependencies
+
 Tested under Ubutnu Linux and Ubuntu in the WSL.
 
-1. Install required packages 
-```
+1. Install required packages
+
+```bash
 sudo apt update
 sudo apt install python3-pip nodejs
 ```
 
 2. Install Rust if not present (not included by default on WSL Ubuntu)
-```
+
+```bash
 curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh
 ```
 
 3. Install required Python modules
-```
+
+```bash
 pip install python_jwt
 ```
 
-5. Install [Circom](https://github.com/iden3/circom) 
+4. Install [Circom](https://github.com/iden3/circom)
 
-```
+```bash
 git clone https://github.com/iden3/circom.git
 cd circom
 git checkout v2.1.6
@@ -44,21 +46,35 @@ cargo install --path circom
 export PATH=$PATH:~/.cargo/bin
 ```
 
-6. [Circomlib](https://github.com/iden3/circomlib) is included as a git submodule that must be initialized. 
+5. [Circomlib](https://github.com/iden3/circomlib) is included as a git submodule that must be initialized.
 Either clone this repo with the option `--recurse-submodules`, or for existing repositories
-```
+
+```bash
 git submodule update --init --recursive
 ```
 
-7. For mDL credentials, the [pyMDOC-CBOR](https://github.com/IdentityPython/pyMDOC-CBOR) Python module must be installed, with the command
-```
+6. For mDL credentials, the [pyMDOC-CBOR](https://github.com/IdentityPython/pyMDOC-CBOR) Python module must be installed, with the command
+
+```bash
+# Linux
 pip install git+https://github.com/peppelinux/pyMDOC-CBOR.git
 ```
 
-## Sample JWT and mDL
-To work with Crescent, the prover and verifier both need the issuer's public key, and the prover needs a JWT. 
-The setup script will generate a sample JWT in `inputs/rs256`.
+```bash
+# Windows
+# pyMDL-MDOC has a bug in the setup we need to fix for proper installation on Windows
+git clone https://github.com/peppelinux/pyMDL-MDOC.git
+cd pyMDL-MDOC
+sed -i "s|i.replace(f'{_pkg_name}/', '')|i.replace(f'{_pkg_name}\\\\\\\\', '')|g" setup.py
+pip install .
 ```
+
+## Sample JWT and mDL
+
+To work with Crescent, the prover and verifier both need the issuer's public key, and the prover needs a JWT.
+The setup script will generate a sample JWT in `inputs/rs256`.
+
+```bash
     inputs/rs256/token.jwt
     inputs/rs256/issuer.pub
 ```
@@ -66,28 +82,29 @@ The setup script will generate a sample JWT in `inputs/rs256`.
 We provide a sample mDL credential in `/inputs/mdl1/`.
 
 ## Running Setup
+
 We describe how to run setup for the sample token provided in `inputs/rs256/`.  This is a JWT, with similar claims to those issued by Microsoft Entra for enterprise users, but created with a freshly generated keypair.
-All of the artifacts created by Crescent for the instance `rs256` will be written to `generated_files/rs256/`. 
+All of the artifacts created by Crescent for the instance `rs256` will be written to `generated_files/rs256/`.
 
 The file `inputs/rs256/config.json` contains a "proof specification", some basic information necessary to create the proof, such as the token length and which claims are to be revealed.
 To run setup, change to the `scripts` directory and run the command
-```
+
+```bash
 ./run_setup.sh rs256
 ```
-Setup runs Circom and creates the R1CS instance to verify the JWT and reaveal some of the outputs, as well
-as the setup steps of the ZK proof system to get the prover and verifier parameters (output as files in `generated_files/rs256`). 
-Overall this is slow, but only needs to be run once for a given token issuer and proof specification. 
+
+Setup runs Circom and creates the R1CS instance to verify the JWT and reveal some of the outputs, as well
+as the setup steps of the ZK proof system to get the prover and verifier parameters (output as files in `generated_files/rs256`).
+Overall this is slow, but only needs to be run once for a given token issuer and proof specification.
 
 Once this script completes, all files required for showing and verifying proofs will have copied to `creds/test-vectors/rs256`.
 
-
-
 # Troubleshooting
-For some large circuits, Circom may use a large amount of RAM and be killed. 
+
+For some large circuits, Circom may use a large amount of RAM and be killed.
 If the log output during Circom compilation stops abruptly, check towards the end of `/var/log/kern.log`
-for an entry like 
-```
+for an entry like
+
+```bash
 Oct  9 16:09:18 computer-name kernel: [22997.693985] Out of memory: Killed process 13747 (circom) total-vm:31880260kB, anon-rss:30334800kB, file-rss:0kB, shmem-rss:0kB, UID:1000 pgtables:62048kB oom_score_adj:0
 ```
-
-


### PR DESCRIPTION
- Add section to Crescent README to deal with unresolved symlink on windows
- Add section to circuit_setupt/README to fix bad installation of python package pymdoccbor
- Additional formatting from running a markdown linter
- A couple minor spelling fixes