### PR TITLE
Updated version of client's package-lock.json

### DIFF
--- a/sample/client/package-lock.json
+++ b/sample/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Crescent Browser Extension",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Crescent Browser Extension",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "28.0.0",


### PR DESCRIPTION
Regenerated the `package-lock.json` file for the client's browser extension (after version number update)