### PR TITLE
Added presentation message to DL proof generation and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ and we can run each step as follows
 ```bash
 cargo run --bin crescent --release --features print-trace zksetup --name rs256
 cargo run --bin crescent --release --features print-trace prove --name rs256
-cargo run --bin crescent --release --features print-trace show --name rs256
-cargo run --bin crescent --release --features print-trace verify --name rs256
+cargo run --bin crescent --release --features print-trace show --name rs256 [--presentation-message "..."]
+cargo run --bin crescent --release --features print-trace verify --name rs256 [--presentation-message "..."]
 ```
 
-The `--name` parameter, used in circuit setup and with the command-line tool, specifies which credential type is used, the two examples are `rs256`, a JWT signed with RSA256, and `mdl1` a sample mobile driver's license.
+The `--name` parameter, used in circuit setup and with the command-line tool, specifies which credential type is used, the two examples are `rs256`, a JWT signed with RSA256, and `mdl1` a sample mobile driver's license. An optional text presentation message can be passed to the `show` and `prove` steps to bind the presentation to some application data (e.g., a verifier challenge, some data to sign).
 
 Note that the steps have to be run in order, but once the client state is created by `prove`, the `show` and `verify` steps can be run repeatedly.
 

--- a/creds/benches/proof_benchmark.rs
+++ b/creds/benches/proof_benchmark.rs
@@ -114,21 +114,23 @@ pub fn show_bench(c: &mut Criterion) {
     );
 
     let io_types = vec![PublicIOType::Hidden; client_state.inputs.len()];
+    let pm = "some presentation message".as_bytes();
 
-    let showing = client_state.show_groth16(&io_types);
+    let showing = client_state.show_groth16(Some(pm), &io_types);
     c.bench_function(&format!("Show with {} hidden inputs", NUM_INPUTS), |b| {
         b.iter(|| {
-            client_state.show_groth16(&io_types);
+            client_state.show_groth16(Some(pm), &io_types);
         })
     });
 
-    showing.verify(&vk, &pvk, &io_types, &vec![]);
+    showing.verify(&vk, &pvk, Some(pm), &io_types, &vec![]);
     c.bench_function(&format!("Verify with {} hidden inputs", NUM_INPUTS), |b| {
         b.iter(|| {
             ShowGroth16::<Bn254>::verify(
                 black_box(&showing),
                 black_box(&vk),
                 black_box(&pvk),
+                Some(pm), 
                 &io_types,
                 &vec![],
             );

--- a/creds/src/dlog.rs
+++ b/creds/src/dlog.rs
@@ -31,9 +31,11 @@ pub struct PedersenOpening<G: CurveGroup> {
 impl<G: Group> DLogPoK<G> {
     /// proves knowledge of the representations of y1, y2, ... y_n
     /// in their respective bases -- bases[1], bases[2], ... bases[n]
+    /// binding the proof to a presentation message pm
     /// optionally, specify a set of positions to assert equality of in the form {(i1,j1), (i2,j2), ...}
     /// TODO (perf): shrink the proof size by compressing the responses since they're the same for all the equal positions
     pub fn prove(
+        pm: Option<&[u8]>,
         y: &[G],
         bases: &[Vec<G>],
         scalars: &[Vec<G::ScalarField>],
@@ -50,6 +52,8 @@ impl<G: Group> DLogPoK<G> {
         let mut r = Vec::new();
 
         let mut ts: Transcript = Transcript::new(&[0u8]);
+        let pm = pm.unwrap_or(b"null");
+        add_to_transcript(&mut ts, b"presentation_message", &pm);
 
         for i in 0..y.len() {
             let mut ri = Vec::new();
@@ -112,8 +116,10 @@ impl<G: Group> DLogPoK<G> {
 
     pub fn verify(
         &self,
+        pm: Option<&[u8]>,
         bases: &[Vec<G>],
         y: &[G],
+        // TODO: add presentation message
         eq_pos: Option<Vec<(usize, usize)>>,
     ) -> bool
     where
@@ -123,6 +129,8 @@ impl<G: Group> DLogPoK<G> {
         // serialize and hash the bases, k and y
         let dl_verify_timer = start_timer!(|| format!("DlogPoK verify y.len = {}", y.len()));
         let mut ts: Transcript = Transcript::new(&[0u8]);
+        let pm = pm.unwrap_or(b"null");
+        add_to_transcript(&mut ts, b"presentation_message", &pm);
 
         let mut recomputed_k = Vec::new();
         for i in 0..y.len() {
@@ -227,14 +235,40 @@ mod tests {
             scalars[i] = F::rand(rng);
             y += bases[i] * scalars[i];
         }
+
+        let pm = "some presentation message".as_bytes();
+
         let pok = DLogPoK::<G1>::prove(
+            Some(pm),
             &[y, y],
             &[bases.clone(), bases.clone()],
             &[scalars.clone(), scalars.clone()],
             Some(vec![(0, 1), (1, 1)]),
         );
 
+        // verify with the wrong bases
+        let wrong_bases = vec![G1::zero(); num_terms];
+        let wrong_bases_result = pok.verify(
+            Some(pm),
+            &[wrong_bases.clone(), wrong_bases.clone()],
+            &[y, y],
+            Some(vec![(0, 1), (1, 1)]),
+        );
+        assert!(!wrong_bases_result, "Verification should fail with the wrong bases");
+
+        // verify with the wrong pm
+        let wrong_pm = "wrong presentation message".as_bytes();
+        let wrong_pm_result = pok.verify(
+            Some(wrong_pm),
+            &[bases.clone(), bases.clone()],
+            &[y, y],
+            Some(vec![(0, 1), (1, 1)]),
+        );
+        assert!(!wrong_pm_result, "Verification should fail with the wrong presentation message");
+
+        // successful verification
         let result = pok.verify(
+            Some(pm),
             &[bases.clone(), bases.clone()],
             &[y, y],
             Some(vec![(0, 1), (1, 1)]),
@@ -242,5 +276,4 @@ mod tests {
 
         assert!(result);
     }
-
 }

--- a/creds/src/dlog.rs
+++ b/creds/src/dlog.rs
@@ -52,7 +52,7 @@ impl<G: Group> DLogPoK<G> {
         let mut r = Vec::new();
 
         let mut ts: Transcript = Transcript::new(&[0u8]);
-        let pm = pm.unwrap_or(b"null");
+        let pm = pm.unwrap_or(b"");
         add_to_transcript(&mut ts, b"presentation_message", &pm);
 
         for i in 0..y.len() {
@@ -119,7 +119,6 @@ impl<G: Group> DLogPoK<G> {
         pm: Option<&[u8]>,
         bases: &[Vec<G>],
         y: &[G],
-        // TODO: add presentation message
         eq_pos: Option<Vec<(usize, usize)>>,
     ) -> bool
     where
@@ -129,7 +128,7 @@ impl<G: Group> DLogPoK<G> {
         // serialize and hash the bases, k and y
         let dl_verify_timer = start_timer!(|| format!("DlogPoK verify y.len = {}", y.len()));
         let mut ts: Transcript = Transcript::new(&[0u8]);
-        let pm = pm.unwrap_or(b"null");
+        let pm = pm.unwrap_or(b"");
         add_to_transcript(&mut ts, b"presentation_message", &pm);
 
         let mut recomputed_k = Vec::new();

--- a/creds/src/groth16rand.rs
+++ b/creds/src/groth16rand.rs
@@ -93,7 +93,7 @@ impl<E: Pairing> ClientState<E> {
         self.serialize_uncompressed(buf_writer).unwrap();
     }
 
-    pub fn show_groth16(&mut self, io_types: &[PublicIOType]) -> ShowGroth16<E> 
+    pub fn show_groth16(&mut self, pm: Option<&[u8]>, io_types: &[PublicIOType]) -> ShowGroth16<E> 
     where
         <E as Pairing>::G1: CurveGroup + VariableBaseMSM,  
     {
@@ -167,7 +167,7 @@ impl<E: Pairing> ClientState<E> {
         // com_l = l1^input1 l2^input2 ... ln^input_n g^z
         // optimized to ignore public inputs
 
-        let pok_inputs = DLogPoK::<E::G1>::prove(&y, &bases, &scalars, None);
+        let pok_inputs = DLogPoK::<E::G1>::prove(pm, &y, &bases, &scalars, None);
         
         end_timer!(groth16_timer);
 
@@ -222,6 +222,7 @@ impl<E: Pairing> ShowGroth16<E> {
         &self,
         vk: &VerifyingKey<E>,
         pvk: &PreparedVerifyingKey<E>,
+        pm: Option<&[u8]>,
         io_types: &[PublicIOType],
         public_inputs: &[E::ScalarField],
     ) -> bool
@@ -284,7 +285,7 @@ impl<E: Pairing> ShowGroth16<E> {
         };
         end_timer!(t);
 
-        let dlog_pok_valid = self.pok_inputs.verify(&bases, &y, None);
+        let dlog_pok_valid = self.pok_inputs.verify(pm, &bases, &y, None);
         
         end_timer!(groth16_timer);
 

--- a/creds/src/lib.rs
+++ b/creds/src/lib.rs
@@ -247,7 +247,7 @@ pub fn create_client_state(paths : &CachePaths, prover_inputs: &GenericInputsJSO
     Ok(client_state)
 }
 
-pub fn create_show_proof(client_state: &mut ClientState<ECPairing>, range_pk : &RangeProofPK<ECPairing>, io_locations: &IOLocations) -> ShowProof<ECPairing>
+pub fn create_show_proof(client_state: &mut ClientState<ECPairing>, range_pk : &RangeProofPK<ECPairing>, pm: Option<&[u8]>, io_locations: &IOLocations) -> ShowProof<ECPairing>
 {
     // Create Groth16 rerandomized proof for showing
     let exp_value_pos = io_locations.get_io_location("exp_value").unwrap();
@@ -259,7 +259,7 @@ pub fn create_show_proof(client_state: &mut ClientState<ECPairing>, range_pk : &
 
     let revealed_inputs = vec![client_state.inputs[email_value_pos-1]];
 
-    let show_groth16 = client_state.show_groth16(&io_types);
+    let show_groth16 = client_state.show_groth16(pm, &io_types);
     
     // Create fresh range proof 
     let time_sec = SystemTime::now()
@@ -279,7 +279,7 @@ pub fn create_show_proof(client_state: &mut ClientState<ECPairing>, range_pk : &
     ShowProof{ show_groth16, show_range, show_range2: None, revealed_inputs, inputs_len: client_state.inputs.len(), cur_time: time_sec}
 }
 
-pub fn create_show_proof_mdl(client_state: &mut ClientState<ECPairing>, range_pk : &RangeProofPK<ECPairing>, io_locations: &IOLocations, age: usize) -> ShowProof<ECPairing>
+pub fn create_show_proof_mdl(client_state: &mut ClientState<ECPairing>, range_pk : &RangeProofPK<ECPairing>, pm: Option<&[u8]>, io_locations: &IOLocations, age: usize) -> ShowProof<ECPairing>
 {
     // Create Groth16 rerandomized proof for showing
     let valid_until_value_pos = io_locations.get_io_location("valid_until_value").unwrap();
@@ -291,7 +291,7 @@ pub fn create_show_proof_mdl(client_state: &mut ClientState<ECPairing>, range_pk
 
     let revealed_inputs : Vec<<ECPairing as Pairing>::ScalarField> = vec![];
 
-    let show_groth16 = client_state.show_groth16(&io_types);    
+    let show_groth16 = client_state.show_groth16(pm, &io_types);    
     
     // Create fresh range proof for validUntil
     let time_sec = SystemTime::now()
@@ -316,7 +316,7 @@ pub fn create_show_proof_mdl(client_state: &mut ClientState<ECPairing>, range_pk
     ShowProof{ show_groth16, show_range, show_range2: Some(show_range2), revealed_inputs, inputs_len: client_state.inputs.len(), cur_time: time_sec}
 }
 
-pub fn verify_show(vp : &VerifierParams<ECPairing>, show_proof: &ShowProof<ECPairing>) -> (bool, String)
+pub fn verify_show(vp : &VerifierParams<ECPairing>, show_proof: &ShowProof<ECPairing>, pm: Option<&[u8]>) -> (bool, String)
 {
     let io_locations = IOLocations::new_from_str(&vp.io_locations_str);
     let exp_value_pos = io_locations.get_io_location("exp_value").unwrap();
@@ -341,7 +341,7 @@ pub fn verify_show(vp : &VerifierParams<ECPairing>, show_proof: &ShowProof<ECPai
     // }
 
     let verify_timer = std::time::Instant::now();
-    let ret = show_proof.show_groth16.verify(&vp.vk, &vp.pvk, &io_types, &inputs);
+    let ret = show_proof.show_groth16.verify(&vp.vk, &vp.pvk, pm, &io_types, &inputs);
     if !ret {
         println!("show_groth16.verify failed");
         return (false, "".to_string());
@@ -392,7 +392,7 @@ pub fn verify_show(vp : &VerifierParams<ECPairing>, show_proof: &ShowProof<ECPai
     (true, domain)
 }
 
-pub fn verify_show_mdl(vp : &VerifierParams<ECPairing>, show_proof: &ShowProof<ECPairing>, age: usize) -> (bool, String)
+pub fn verify_show_mdl(vp : &VerifierParams<ECPairing>, show_proof: &ShowProof<ECPairing>, pm: Option<&[u8]>, age: usize) -> (bool, String)
 {
     let io_locations = IOLocations::new_from_str(&vp.io_locations_str);
     let valid_until_value_pos = io_locations.get_io_location("valid_until_value").unwrap();
@@ -418,7 +418,7 @@ pub fn verify_show_mdl(vp : &VerifierParams<ECPairing>, show_proof: &ShowProof<E
     // }
 
     let verify_timer = std::time::Instant::now();
-    show_proof.show_groth16.verify(&vp.vk, &vp.pvk, &io_types, &inputs);
+    show_proof.show_groth16.verify(&vp.vk, &vp.pvk, pm, &io_types, &inputs);
     let cur_time = Fr::from(show_proof.cur_time);
     let now_seconds = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
     let delta = 
@@ -533,12 +533,13 @@ mod tests {
         let mut client_state: ClientState<CrescentPairing> = read_from_file(&paths.client_state).unwrap();
 
         println!("Running show");
+        let pm = "some presentation message".as_bytes();
         let io_locations = IOLocations::new(&paths.io_locations);    
         let range_pk : RangeProofPK<CrescentPairing> = read_from_file(&paths.range_pk).unwrap();
         let show_proof = if client_state.credtype == "mdl" {
-            create_show_proof_mdl(&mut client_state, &range_pk, &io_locations, MDL_AGE_GT)  
+            create_show_proof_mdl(&mut client_state, &range_pk, Some(pm), &io_locations, MDL_AGE_GT)  
         } else {
-            create_show_proof(&mut client_state, &range_pk, &io_locations)
+            create_show_proof(&mut client_state, &range_pk, Some(pm), &io_locations)
         };
 
         write_to_file(&show_proof, &paths.show_proof);
@@ -554,9 +555,9 @@ mod tests {
         let vp = VerifierParams{vk, pvk, range_vk, io_locations_str, issuer_pem};
     
         let (verify_result, _data) = if show_proof.show_range2.is_some() {
-            verify_show_mdl(&vp, &show_proof, MDL_AGE_GT)
+            verify_show_mdl(&vp, &show_proof, Some(pm), MDL_AGE_GT)
         } else {
-            verify_show(&vp, &show_proof)
+            verify_show(&vp, &show_proof, Some(pm))
         };
         assert!(verify_result);
     }

--- a/creds/src/lib.rs
+++ b/creds/src/lib.rs
@@ -419,6 +419,11 @@ pub fn verify_show_mdl(vp : &VerifierParams<ECPairing>, show_proof: &ShowProof<E
 
     let verify_timer = std::time::Instant::now();
     show_proof.show_groth16.verify(&vp.vk, &vp.pvk, pm, &io_types, &inputs);
+    let ret = show_proof.show_groth16.verify(&vp.vk, &vp.pvk, pm, &io_types, &inputs);
+    if !ret {
+        println!("show_groth16.verify failed");
+        return (false, "".to_string());
+    }
     let cur_time = Fr::from(show_proof.cur_time);
     let now_seconds = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
     let delta = 

--- a/creds/src/main.rs
+++ b/creds/src/main.rs
@@ -35,15 +35,17 @@ fn main() {
             let base_path = root.join(name_path);
             run_prover(base_path);
         }
-        Command::Show { name } => {
+        Command::Show { name, presentation_message } => {
             let name_path = format!("test-vectors/{}", name);
             let base_path = root.join(name_path);
-            run_show(base_path);
+            println!("presentation_message: {:?}", presentation_message);
+            run_show(base_path, presentation_message);
         }        
-        Command::Verify { name } => {
+        Command::Verify { name, presentation_message } => {
             let name_path = format!("test-vectors/{}", name);
             let base_path = root.join(name_path);
-            run_verifier(base_path);
+            println!("presentation_message: {:?}", presentation_message);
+            run_verifier(base_path, presentation_message);
         }
     }
 }
@@ -73,12 +75,16 @@ pub enum Command {
     Show {
         #[structopt(long)]
         name: String,
+        #[structopt(long, about = "Optional presentation message to include in the proof.")]
+        presentation_message: Option<String>,
     },    
 
     #[structopt(about = "Verifier a presentation proof.")]
     Verify {
         #[structopt(long)]
         name: String,
+        #[structopt(long, about = "Optional presentation message to include in the proof.")]
+        presentation_message: Option<String>,
     },
 }
 
@@ -152,29 +158,29 @@ fn show_proof_size(show_proof: &ShowProof<CrescentPairing>) -> usize {
 }
 
 pub fn run_show(
-    base_path: PathBuf
+    base_path: PathBuf,
+    presentation_message: Option<String>
 ) {
     let proof_timer = std::time::Instant::now();    
     let paths = CachePaths::new(base_path);
     let io_locations = IOLocations::new(&paths.io_locations);    
     let mut client_state: ClientState<CrescentPairing> = read_from_file(&paths.client_state).unwrap();
     let range_pk : RangeProofPK<CrescentPairing> = read_from_file(&paths.range_pk).unwrap();
+    let pm = presentation_message.as_deref().map(|s| s.as_bytes());
 
-    // TODO: add command line option to pass in a presentation message
     let show_proof = if client_state.credtype == "mdl" {
-        create_show_proof_mdl(&mut client_state, &range_pk, None, &io_locations, MDL_AGE_GREATER_THAN)  
+        create_show_proof_mdl(&mut client_state, &range_pk, pm, &io_locations, MDL_AGE_GREATER_THAN)  
     } else {
         create_show_proof(&mut client_state, &range_pk, None, &io_locations)
     };
     println!("Proving time: {:?}", proof_timer.elapsed());
 
-    //let _ = _show_groth16_proof_size(&show_proof.show_groth16);
     let _ = show_proof_size(&show_proof);
 
     write_to_file(&show_proof, &paths.show_proof);
 }
 
-pub fn run_verifier(base_path: PathBuf) {
+pub fn run_verifier(base_path: PathBuf, presentation_message: Option<String>) {
     let paths = CachePaths::new(base_path);
     let show_proof : ShowProof<CrescentPairing> = read_from_file(&paths.show_proof).unwrap();
     let pvk : PreparedVerifyingKey<CrescentPairing> = read_from_file(&paths.groth16_pvk).unwrap();
@@ -184,12 +190,12 @@ pub fn run_verifier(base_path: PathBuf) {
     let issuer_pem = std::fs::read_to_string(&paths.issuer_pem).unwrap();
 
     let vp = VerifierParams{vk, pvk, range_vk, io_locations_str, issuer_pem};
+    let pm = presentation_message.as_deref().map(|s| s.as_bytes());
 
-    // TODO: add command line option to pass in a presentation message
     let (verify_result, data) = if show_proof.show_range2.is_some() {
-        verify_show_mdl(&vp, &show_proof, None, MDL_AGE_GREATER_THAN)
+        verify_show_mdl(&vp, &show_proof, pm, MDL_AGE_GREATER_THAN)
     } else {
-        verify_show(&vp, &show_proof, None)
+        verify_show(&vp, &show_proof, pm)
     };
 
     if verify_result {

--- a/creds/src/main.rs
+++ b/creds/src/main.rs
@@ -159,11 +159,12 @@ pub fn run_show(
     let io_locations = IOLocations::new(&paths.io_locations);    
     let mut client_state: ClientState<CrescentPairing> = read_from_file(&paths.client_state).unwrap();
     let range_pk : RangeProofPK<CrescentPairing> = read_from_file(&paths.range_pk).unwrap();
-    
+
+    // TODO (FIXME): what should be the presentation message pm?
     let show_proof = if client_state.credtype == "mdl" {
-        create_show_proof_mdl(&mut client_state, &range_pk, &io_locations, MDL_AGE_GREATER_THAN)  
+        create_show_proof_mdl(&mut client_state, &range_pk, None, &io_locations, MDL_AGE_GREATER_THAN)  
     } else {
-        create_show_proof(&mut client_state, &range_pk, &io_locations)
+        create_show_proof(&mut client_state, &range_pk, None, &io_locations)
     };
     println!("Proving time: {:?}", proof_timer.elapsed());
 
@@ -184,10 +185,11 @@ pub fn run_verifier(base_path: PathBuf) {
 
     let vp = VerifierParams{vk, pvk, range_vk, io_locations_str, issuer_pem};
 
+    // TODO (FIXME): what should be the presentation message pm?
     let (verify_result, data) = if show_proof.show_range2.is_some() {
-        verify_show_mdl(&vp, &show_proof, MDL_AGE_GREATER_THAN)
+        verify_show_mdl(&vp, &show_proof, None, MDL_AGE_GREATER_THAN)
     } else {
-        verify_show(&vp, &show_proof)
+        verify_show(&vp, &show_proof, None)
     };
 
     if verify_result {

--- a/creds/src/main.rs
+++ b/creds/src/main.rs
@@ -38,13 +38,11 @@ fn main() {
         Command::Show { name, presentation_message } => {
             let name_path = format!("test-vectors/{}", name);
             let base_path = root.join(name_path);
-            println!("presentation_message: {:?}", presentation_message);
             run_show(base_path, presentation_message);
         }        
         Command::Verify { name, presentation_message } => {
             let name_path = format!("test-vectors/{}", name);
             let base_path = root.join(name_path);
-            println!("presentation_message: {:?}", presentation_message);
             run_verifier(base_path, presentation_message);
         }
     }
@@ -171,7 +169,7 @@ pub fn run_show(
     let show_proof = if client_state.credtype == "mdl" {
         create_show_proof_mdl(&mut client_state, &range_pk, pm, &io_locations, MDL_AGE_GREATER_THAN)  
     } else {
-        create_show_proof(&mut client_state, &range_pk, None, &io_locations)
+        create_show_proof(&mut client_state, &range_pk, pm, &io_locations)
     };
     println!("Proving time: {:?}", proof_timer.elapsed());
 

--- a/creds/src/main.rs
+++ b/creds/src/main.rs
@@ -160,7 +160,7 @@ pub fn run_show(
     let mut client_state: ClientState<CrescentPairing> = read_from_file(&paths.client_state).unwrap();
     let range_pk : RangeProofPK<CrescentPairing> = read_from_file(&paths.range_pk).unwrap();
 
-    // TODO (FIXME): what should be the presentation message pm?
+    // TODO: add command line option to pass in a presentation message
     let show_proof = if client_state.credtype == "mdl" {
         create_show_proof_mdl(&mut client_state, &range_pk, None, &io_locations, MDL_AGE_GREATER_THAN)  
     } else {
@@ -185,7 +185,7 @@ pub fn run_verifier(base_path: PathBuf) {
 
     let vp = VerifierParams{vk, pvk, range_vk, io_locations_str, issuer_pem};
 
-    // TODO (FIXME): what should be the presentation message pm?
+    // TODO: add command line option to pass in a presentation message
     let (verify_result, data) = if show_proof.show_range2.is_some() {
         verify_show_mdl(&vp, &show_proof, None, MDL_AGE_GREATER_THAN)
     } else {

--- a/creds/src/rangeproof.rs
+++ b/creds/src/rangeproof.rs
@@ -230,6 +230,7 @@ impl<E: Pairing> RangeProof<E> {
 
         // Link com_f to ped_open via a DLEQ proof
         let dleq_proof = DLogPoK::<E::G1>::prove(
+            None, // TODO (FIXME): should we add a presentation message here?
             &[ped_open.c, com_f.0.into()],
             &[
                 ped_open
@@ -415,6 +416,7 @@ impl<E: Pairing> RangeProof<E> {
         self
             .dleq_proof
             .verify(
+                None, // TODO (FIXME): should we add a presentation message here?
                 &[bases.to_vec(), vk.com_f_basis.to_vec(),],
                 &[*ped_com, self.com_f.0.into()],
                 Some(vec![(0, 0), (1, 3)]),
@@ -517,8 +519,9 @@ mod tests {
         io_types[0] = PublicIOType::Revealed;
         io_types[1] = PublicIOType::Committed;
     
-        let showing = client_state.show_groth16(&io_types);
-        showing.verify(&vk, &pvk, &io_types, &[inputs[0]]);
+        let pm = "some presentation message".as_bytes();
+        let showing = client_state.show_groth16(Some(pm), &io_types);
+        showing.verify(&vk, &pvk, Some(pm), &io_types, &[inputs[0]]);
     
         println!(
             "Committed to input: {}",

--- a/creds/src/rangeproof.rs
+++ b/creds/src/rangeproof.rs
@@ -230,7 +230,7 @@ impl<E: Pairing> RangeProof<E> {
 
         // Link com_f to ped_open via a DLEQ proof
         let dleq_proof = DLogPoK::<E::G1>::prove(
-            None, // TODO (FIXME): should we add a presentation message here?
+            None, // TODO: should we add a presentation message here? (use the c from the dlog proof?)
             &[ped_open.c, com_f.0.into()],
             &[
                 ped_open
@@ -416,7 +416,7 @@ impl<E: Pairing> RangeProof<E> {
         self
             .dleq_proof
             .verify(
-                None, // TODO (FIXME): should we add a presentation message here?
+                None, // TODO: should we add a presentation message here?
                 &[bases.to_vec(), vk.com_f_basis.to_vec(),],
                 &[*ped_com, self.com_f.0.into()],
                 Some(vec![(0, 0), (1, 3)]),

--- a/forks/circom-compat/src/circom/qap.rs
+++ b/forks/circom-compat/src/circom/qap.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]  // Disable warnings emitted by use of cfg_iter*
+
 use ark_ff::PrimeField;
 use ark_groth16::r1cs_to_qap::{evaluate_constraint, LibsnarkReduction, R1CSToQAP};
 use ark_poly::EvaluationDomain;

--- a/sample/client_helper/src/main.rs
+++ b/sample/client_helper/src/main.rs
@@ -273,10 +273,10 @@ async fn show<'a>(cred_uid: String, disc_uid: String, state: &State<SharedState>
             let show_proof =
             if &client_state.credtype == "mdl" {
                 let age = disc_uid_to_age(&disc_uid).map_err(|_| "Disclosure UID does not have associated age parameter".to_string())?;
-                create_show_proof_mdl(&mut client_state, &range_pk, &io_locations, age)
+                create_show_proof_mdl(&mut client_state, &range_pk, None, &io_locations, age)
             }
             else {
-                create_show_proof(&mut client_state, &range_pk, &io_locations)            
+                create_show_proof(&mut client_state, &range_pk, None, &io_locations)            
             };
             
             // Return the show proof as a base64-url encoded string

--- a/sample/verifier/src/main.rs
+++ b/sample/verifier/src/main.rs
@@ -275,12 +275,12 @@ async fn verify(proof_info: Json<ProofInfo>, verifier_config: &State<VerifierCon
     let is_valid;
     let disclosed_info;
     if cred_type == "jwt" {
-        let (valid, info) = verify_show(&vp, &show_proof);
+        let (valid, info) = verify_show(&vp, &show_proof, None);
         is_valid = valid;
         disclosed_info = Some(info);
     } else {
         let age = disc_uid_to_age(&proof_info.disclosure_uid).unwrap(); // disclosure UID validated, so unwrap should be safe
-        let (valid, info) = verify_show_mdl(&vp, &show_proof, age);
+        let (valid, info) = verify_show_mdl(&vp, &show_proof, None, age);
         is_valid = valid;
         disclosed_info = Some(info);
     }


### PR DESCRIPTION
Adds a presentation message to the DL proof generation and validation process. Addresses part 1 of issue #89.

The presentation message is expected by the `DLogPoK` `prove` and `verify` functions, which in turn is passed in through the Groth16 show and verify functions.
