### PR TITLE
fix circomlib symlink on Windows;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ circuit_setup/inputs/*/issuer.pub
 circuit_setup/inputs/*/token.jwt
 
 setup/generated_files/
+circuit_setup/circuits-mdl/circomlib

--- a/circuit_setup/scripts/run_setup.sh
+++ b/circuit_setup/scripts/run_setup.sh
@@ -49,6 +49,11 @@ else
     CIRCOM_SRC_DIR="${ROOT_DIR}/circuits"
 fi
 
+# Replace symlink with junction if on Windows
+if [ -f "${CIRCOM_SRC_DIR}/circomlib" ]; then
+    rm -f "${CIRCOM_SRC_DIR}/circomlib"
+    cmd //c "mklink /J ${CIRCOM_SRC_DIR##*/}\circomlib circuits\circomlib"
+fi
 
 # Create the output directory if not there.
 mkdir $OUTPUTS_DIR 2>/dev/null || true


### PR DESCRIPTION
On Windows, git will not automatically create symlinks when cloning repos without a changing a git setting. 
Also, Windows requires elevated privileges to create symlinks.
We'll use junctions instead.
- In `run_setup.sh`, Detect the unconverted symlink file and replace with junction if on Windows.