### PR TITLE
Replace rug crate with num-bigint

### DIFF
--- a/creds/Cargo.toml
+++ b/creds/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = {version = "1.0", features = ["preserve_order"]}
 serde = { version = "1.0", features = ["derive"] }
 
 # wasmer
-num-bigint = { version = "=0.4.3", default-features = false, features = [
+num-bigint = { version = "=0.4", default-features = false, features = [
     "rand",
 ] }
 num-traits = "0.2.14"

--- a/creds/src/wasm_lib.rs
+++ b/creds/src/wasm_lib.rs
@@ -90,8 +90,8 @@ pub fn create_show_proof_wasm(
                     age.expect("Age not valid."),
                 )
             } else {
-                proof_spec.presentation_message = Some(challenge);
-                create_show_proof(&mut client_state, &range_pk, &io_locations, &proof_spec).unwrap()
+                proof_spec.presentation_message = Some(challenge.into());
+                create_show_proof(&mut client_state, &range_pk, &io_locations, &proof_spec, None).unwrap()
             };
 
             let show_proof_b64 = write_to_b64url(&show_proof);

--- a/ecdsa-pop/Cargo.lock
+++ b/ecdsa-pop/Cargo.lock
@@ -189,12 +189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "az"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
-
-[[package]]
 name = "bellpepper"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +220,12 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -382,12 +382,24 @@ dependencies = [
  "ff-derive-num",
  "ff_derive",
  "lazy_static",
+ "num-bigint 0.2.6",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-primes",
  "num-traits",
  "paste",
  "rand 0.8.5",
- "rug",
  "serde",
  "sha2",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -397,7 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -631,6 +643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,16 +721,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0205cd82059bc63b63cf516d714352a30c44f2c74da9961dfda2617ae6b5918"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "group"
@@ -846,6 +854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +897,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+ "rand 0.5.6",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +941,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -919,6 +959,15 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -947,6 +996,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-primes"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f25459a616100b36b5af31d8b05abbee29a5f29f83ddf95e78cb2268ab300a"
+dependencies = [
+ "log",
+ "num",
+ "num-bigint 0.2.6",
+ "num-traits",
+ "rand 0.5.6",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
  "num-integer",
  "num-traits",
 ]
@@ -1049,6 +1121,19 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -1114,6 +1199,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -1176,19 +1276,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rug"
-version = "1.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4207e8d668e5b8eb574bda8322088ccd0d7782d3d03c7e8d562e82ed82bdcbc3"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
- "serde",
 ]
 
 [[package]]
@@ -1314,7 +1401,6 @@ dependencies = [
  "num-bigint-dig",
  "rand 0.7.3",
  "rayon",
- "rug",
  "serde",
  "serde_bytes",
  "sha3 0.8.2",
@@ -1458,13 +1544,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.52.0"
+name = "winapi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "windows-targets",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -1545,7 +1644,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]

--- a/ecdsa-pop/Cargo.toml
+++ b/ecdsa-pop/Cargo.toml
@@ -14,11 +14,11 @@ ff = { version = "0.13.0", features = ["derive"] }
 #neptune = { version = "13.0.0", default-features = false } # Poseidon.  v13 depends on bellpepper 4.0, but spartan must use 2.0
 neptune = {path = './neptune', default-features = false}   # Our fork of neptune that works with bellpepper 2.0
 generic-array = "1.0.0"
-halo2curves = { version = "0.8.0", features =["derive_serde", "asm"]}
+halo2curves = { version = "0.8.0", features =["derive_serde",]}
 merlin = { version = "3.0.0", default-features = false }
 hex = "0.4.3"
 sha2 = "0.10.7"
-num-bigint = {version="0.4.3", features = ["rand"]}
+num-bigint = {version="0.4", features = ["rand"]}
 num-traits = "0.2.14"
 thiserror = "1.0.39"
 ark-std = "0.4.0"

--- a/forks/Spartan-t256/Cargo.toml
+++ b/forks/Spartan-t256/Cargo.toml
@@ -42,7 +42,6 @@ crrl = "0.9.0"
 ff = { version = "0.13.0", features = ["derive"] }
 bellpepper-core = { version="0.2.0", default-features = false }
 bellpepper = { version="0.2.0", default-features = false }
-rug = { version = "1.11", features = ["serde"] }
 
 
 [dev-dependencies]

--- a/forks/Spartan-t256/circ_fields/Cargo.toml
+++ b/forks/Spartan-t256/circ_fields/Cargo.toml
@@ -14,7 +14,7 @@ lazy_static = "1.4"
 num-traits = "0.2"
 paste = "1.0"
 rand = "0.8"
-rug = { version = "1.11", features = ["serde"] }
+# rug = { version = "1.11", features = ["serde"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 datasize = { version = "0.2", features = ["detailed"] }
 ark-ff = { version = "0.4.2", default-features = false }
@@ -24,6 +24,14 @@ ark-std = { version = "0.4.0", default-features = false }
 ark-secp256r1 = {default-features = false, git = "https://github.com/arkworks-rs/curves" }
 ark-ff-macros =  { version = "0.4.2", default-features = false }
 ark-serialize = { version = "0.4.2", default-features = false }
+num-bigint = { version = "0.4", features = ["serde", "rand"]   }
+num-bigint-02 = { package = "num-bigint", version = "0.2" }
+num-integer = "0.1"
+num-primes = { version = "0.3" }
 
 [dev-dependencies]
 rand = "0.8"
+
+[features]
+default = []
+wasm = []

--- a/forks/Spartan-t256/circ_fields/src/size.rs
+++ b/forks/Spartan-t256/circ_fields/src/size.rs
@@ -1,9 +1,9 @@
 //! Heap Size helpers for use with [datasize].
 
-use rug::Integer;
+use num_bigint::BigInt;
 
 /// Measure memory footprint of an integer
-pub fn estimate_heap_size_integer(i: &Integer) -> usize {
+pub fn estimate_heap_size_integer(i: &BigInt) -> usize {
     // a guess
-    i.capacity() / 8
+    (i.bits() as usize + 7) / 8
 }

--- a/forks/Spartan-t256/circ_fields/src/test.rs
+++ b/forks/Spartan-t256/circ_fields/src/test.rs
@@ -1,7 +1,11 @@
 use super::*;
 use rand::thread_rng;
 use rand::Rng;
-use rug::ops::RemRounding;
+use num_bigint::BigInt as Integer;
+use num_integer::Integer as NumInteger;
+use num_traits::{One, Signed};
+use num_primes::Verification;
+use num_bigint_02::BigUint as BigUint02;
 
 #[test]
 fn inline_signed_bits() {
@@ -32,7 +36,6 @@ fn inline_signed_bits() {
         64
     );
 }
-use rug::Integer;
 
 #[test]
 fn inline_signed_bits_randomized() {
@@ -44,21 +47,28 @@ fn inline_signed_bits_randomized() {
         let big_i = Integer::from(i);
         assert_eq!(
             InlineFieldV(i, InlineFieldTag::Bls12381).signed_bits(),
-            big_i.signed_bits(),
+            signed_bits(&big_i),
             "wrong answer on {:b}",
             i
         )
     }
 }
 
+fn signed_bits(x: &Integer) -> u32 {
+    if x.is_negative() {
+        (-(x + Integer::one())).bits() as u32 + 1
+    } else {
+        x.bits() as u32 + 1
+    }
+}
+
 /// Samples a random integer with up to `max_bits` bits.
 ///
 /// A number with `i` is chosen with probability proportional to `2^-i`.
-fn random_rug_int_exp(rng: &mut impl Rng, max_bits: u32) -> Integer {
+fn random_bigint_exp(rng: &mut impl Rng, max_bits: u32) -> Integer {
+    use num_bigint::RandBigInt;
     let num_bits = rng.gen_range(1u32..max_bits);
-    let mut rug_rng = rug::rand::RandState::new_mersenne_twister();
-    rug_rng.seed(&Integer::from(rng.next_u64()));
-    Integer::from(Integer::random_bits(num_bits, &mut rug_rng))
+    rng.gen_biguint(num_bits as u64).into() // into a non-negative BigInt
 }
 
 /// Sample a [FieldT] that is:
@@ -66,28 +76,51 @@ fn random_rug_int_exp(rng: &mut impl Rng, max_bits: u32) -> Integer {
 /// * Bn w/ p = 0.25
 /// * An integer field otherwise
 ///   * with a number of bits sampled uniformly between 1..max_bits
-fn sample_field_t(r: &mut impl Rng, max_bits: u32) -> FieldT {
+pub fn sample_field_t(r: &mut impl Rng, max_bits: u32) -> FieldT {
+    
     if r.gen_bool(0.5) {
-        if r.gen_bool(0.5) {
+        let result = if r.gen_bool(0.5) {
             FieldT::FBls12381
         } else {
             FieldT::FBn254
-        }
+        };
+        result
     } else {
-        FieldT::IntField(Arc::new(random_rug_int_exp(r, max_bits).next_prime()))
+        let result = FieldT::IntField(Arc::new(next_prime(random_bigint_exp(r, max_bits))));        
+        result
     }
 }
 
-/// Sample a [FieldV]. If `ty` is inlinable, the value will be inline with probability 0.5.
+fn next_prime(n: Integer) -> Integer {
+
+    let mut candidate = n;
+
+    if candidate.is_even() {
+        candidate += 1u8;
+    }
+
+    // is_prime below will fail if candidate < 4
+    if candidate < 4u8.into() {
+        candidate = 5u8.into();
+    }
+
+    while !Verification::is_prime(&BigUint02::from_bytes_le(&candidate.to_bytes_le().1)) {
+        candidate += 2u8;
+    }
+
+    candidate
+}
+
 fn sample_field_v(ty: &FieldT, r: &mut impl Rng) -> FieldV {
     if let Some(t) = ty.inline_tag() {
         if r.gen_bool(0.5) {
             let num_bits = r.gen_range(0..62);
             let i: i64 = r.gen();
-            return FieldV::from(InlineFieldV(i % (1 << num_bits as i64), t));
+            return FieldV::from(InlineFieldV(i % (1 << num_bits), t));
         }
     }
-    ty.new_v(random_rug_int_exp(r, ty.modulus().significant_bits()))
+    let i = random_bigint_exp(r, ty.modulus().bits() as u32);
+    ty.new_v(i)
 }
 
 #[test]
@@ -102,22 +135,22 @@ fn random() {
 
         // add
         let c = a.clone() + &b;
-        let c_i = (a_i.clone() + &b_i).rem_floor(f.modulus());
+        let c_i = (a_i.clone() + &b_i).mod_floor(f.modulus());
         assert_eq!(c.i(), c_i);
 
         // sub
         let c = a.clone() - &b;
-        let c_i = (a_i.clone() - &b_i).rem_floor(f.modulus());
+        let c_i = (a_i.clone() - &b_i).mod_floor(f.modulus());
         assert_eq!(c.i(), c_i);
 
         // mul
         let c = a.clone() * &b;
-        let c_i = (a_i.clone() * &b_i).rem_floor(f.modulus());
+        let c_i = (a_i.clone() * &b_i).mod_floor(f.modulus());
         assert_eq!(c.i(), c_i);
 
         // neg
         let c = -a.clone();
-        let c_i = (-a_i.clone()).rem_floor(f.modulus());
+        let c_i = (-a_i.clone()).mod_floor(f.modulus());
         assert_eq!(c.i(), c_i);
     }
 }

--- a/forks/circom-compat/Cargo.toml
+++ b/forks/circom-compat/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 wasmer = { version = "=2.3.0", default-features = false }
 fnv = { version = "=1.0.7", default-features = false }
 num = { version = "=0.4.0" }
-num-traits = { version = "=0.2.15", default-features = false }
-num-bigint = { version = "=0.4.3", default-features = false, features = ["rand"] }
+num-traits = { version = "=0.2", default-features = false }
+num-bigint = { version = "=0.4", default-features = false, features = ["rand"] }
 
 # ZKP Generation
 ark-crypto-primitives = { version = "0.4.0" }


### PR DESCRIPTION
This PR replaces the use of the `rug` crate in `forks/Spartan-t256/circ_fields` with `num-bigint` to remove the dependency on `gmp-mpfr-sys`.

The `rug` crate is a wrapper around `gmp-mpfr-sys`, which in turn wraps the GNU Multiple Precision Arithmetic Library (GMP). While GMP is a high-performance C library for arbitrary-precision arithmetic, it includes CPU-specific assembly code that:

- Cannot be cleanly compiled to WebAssembly
- Fails to build on Windows with the `x86_64-pc-windows-msvc` toolchain due to its reliance on a GNU toolchain during compilation

#### Changes

- Replaced `rug` with `num-bigint` throughout `circ_fields`
- Updated the `num-bigint` dependency from `=0.4.3` to `^0.4` to allow the latest compatible 0.4.x version to be used
  - The minimum required version is `0.4.5`, which introduces the `modinverse` method needed to match functionality previously provided by `rug`
  - The current latest version is `0.4.6`
- Added a couple of functions to replace `rug` functionally not present in `num-bigint`
