### PR TITLE
Detect sample setup failure in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crescent
 
-_version 0.4_
+_version 0.5_
 
 Crescent is a library to generate proofs of possession of JSON Web Tokens (JWT) and
 mobile Driver's Licenses (mDL) credentials.

--- a/sample/client/setup_client.sh
+++ b/sample/client/setup_client.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Define the source and target directories as arrays
 CRESCENT_DIR=("../../creds")

--- a/sample/client_helper/setup_client_helper.sh
+++ b/sample/client_helper/setup_client_helper.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Define the source and target directories as arrays
 SOURCE_DIRS=("../../creds/test-vectors/rs256" "../../creds/test-vectors/rs256-sd" "../../creds/test-vectors/mdl1")

--- a/sample/issuer/setup_issuer.sh
+++ b/sample/issuer/setup_issuer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # call the key generation script
 ../common/generate-keys.sh

--- a/sample/setup-sample.sh
+++ b/sample/setup-sample.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # usage: setup-sample.sh
 

--- a/sample/verifier/setup_verifier.sh
+++ b/sample/verifier/setup_verifier.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Define the source and target directories as arrays
 SOURCE_DIRS=("../../creds/test-vectors/rs256" "../../creds/test-vectors/rs256-sd" "../../creds/test-vectors/mdl1")


### PR DESCRIPTION
Set `set -e` in sample setup scripts to catch errors in CI build.