### PR TITLE
Docker sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ circuit_setup/inputs/*/mdl.cbor
 
 setup/generated_files/
 circuit_setup/circuits-mdl/circomlib
+docker-extension

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ circuit_setup/inputs/*/mdl.cbor
 
 setup/generated_files/
 circuit_setup/circuits-mdl/circomlib
-docker-extension
+crescent-extension

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -5,7 +5,7 @@
 #  besides Docker. The browser extension can be installed from the container to your local browser and will 
 #  connect to the services running in the container.
 #
-#  The browser extension files and sample mdoc are available in /sample/docker-extension in the project
+#  The browser extension files and sample mdl are available in /sample/docker-extension in the project
 #  folder after running instantiating the container with 'docker run'.
 #
 #
@@ -21,7 +21,7 @@
 #  Run the Docker container:
 #
 #    A new folder called 'crescent-extension' will be created in the directory where you run the command.
-#    This folder will contain the browser extension files and the sample mdoc.
+#    This folder will contain the browser extension files and the sample mdl.
 #
 #    # Windows (Cmd)
 #    docker run -v "%cd%\crescent-extension:/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -1,4 +1,40 @@
-FROM ubuntu:22.04
+# 
+#
+#  This Dockerfile is used to build a Docker image for the Crescent credentials project and sample.
+#  You can build and run the sample in the container without installing any dependencies on your local machine
+#  besides Docker. The browser extension can be installed from the container to your local browser and will 
+#  connect to the services running in the container.
+#
+#  The browser extension files and sample mdoc are available in /sample/docker-extension in the project
+#  folder after running instantiating the container with 'docker run'.
+#
+#
+#  Build the Docker image (this can take 30 minutes or more and use 35+ GB of disk space):
+#
+#    # Make sure you are in the root folder of the project even though the Dockerfile is in the sample folder
+#    cd crescent-credentials
+#
+#    # Build the Docker image
+#    docker build -f sample/Dockerfile -t crescent-sample .
+#
+#
+#  Run the Docker container:
+#
+#    A new folder called 'crescent-extension' will be created in the directory where you run the command.
+#    This folder will contain the browser extension files and the sample mdoc.
+#
+#    # Windows (Cmd)
+#    docker run -v "%cd%\crescent-extension:/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
+#
+#    # Windows (Git Bash)
+#    docker run -v "$(pwd -W)\crescent-extension:/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
+#
+#    # Linux
+#    docker run -v "$(pwd)/crescent-extension:/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
+#
+# 
+
+FROM rust:slim
 
 SHELL ["/bin/bash", "-c"]
 
@@ -6,23 +42,28 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV ROCKET_ADDRESS=0.0.0.0
 
 RUN apt-get update && apt-get upgrade -y && apt-get clean
-RUN apt-get install git curl software-properties-common build-essential python3-pip cmake clang libclang-dev llvm-dev m4 bsdextrautils dos2unix -y
-# RUN { add-apt-repository ppa:git-core/ppa -y; apt update; apt install git -y; git --version; }
+RUN apt-get install python3.11-venv python3-pip curl git dos2unix m4 cmake libclang-dev bsdextrautils -y
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs && node -v && npm -v
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
-ENV PATH=/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN pip install --upgrade pip setuptools wheel setuptools-scm
+
+# pip requires a virtual environment to not pollute the system python installation
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+RUN pip install --upgrade pip
 RUN pip install python_jwt git+https://github.com/peppelinux/pyMDOC-CBOR.git
 
+# Install circom
 RUN git clone https://github.com/iden3/circom.git && cd circom && git checkout v2.1.6 && cargo build --release && cargo install --path circom;
+
+# Copy local Crescent source code to the container
 COPY . /crescent-credentials
+
+# Fix line endings for all shell scripts as we may be copying from Windows
 RUN find /crescent-credentials -type f -name "*.sh" -exec dos2unix {} +
 
 WORKDIR /crescent-credentials
 RUN git submodule update --init --recursive;
 
 WORKDIR /crescent-credentials/circuit_setup/scripts
-
 RUN ./run_setup.sh rs256
 RUN ./run_setup.sh rs256-sd
 RUN ./run_setup.sh rs256-db
@@ -33,31 +74,32 @@ RUN cargo run --bin crescent --release --features print-trace zksetup --name rs2
 RUN cargo run --bin crescent --release --features print-trace prove --name rs256
 RUN cargo run --bin crescent --release --features print-trace show --name rs256
 RUN cargo run --bin crescent --release --features print-trace verify --name rs256
-
 RUN cargo run --bin crescent --release --features print-trace zksetup --name rs256-sd
 RUN cargo run --bin crescent --release --features print-trace prove --name rs256-sd
 RUN cargo run --bin crescent --release --features print-trace show --name rs256-sd
 RUN cargo run --bin crescent --release --features print-trace verify --name rs256-sd
-
 RUN cargo run --bin crescent --release --features print-trace zksetup --name rs256-db
 RUN cargo run --bin crescent --release --features print-trace prove --name rs256-db
 RUN cargo run --bin crescent --release --features print-trace show --name rs256-db
 RUN cargo run --bin crescent --release --features print-trace verify --name rs256-db
-
 RUN cargo run --bin crescent --release --features print-trace zksetup --name mdl1
 RUN cargo run --bin crescent --release --features print-trace prove --name mdl1
 RUN cargo run --bin crescent --release --features print-trace show --name mdl1
 RUN cargo run --bin crescent --release --features print-trace verify --name mdl1
 
+WORKDIR /crescent-credentials/ecdsa-pop
+RUN cargo build --release
+
 WORKDIR /crescent-credentials/sample
 RUN ./setup-sample.sh
+
+# Create run script to start all services and copy extension files to the mount folder
 RUN echo '#!/bin/bash' > start-all.sh && \
-    # echo 'cd setup_service && cargo run --release &' >> start-all.sh && \
     echo 'cd client_helper && cargo run --release &' >> start-all.sh && \
     echo 'cd issuer && cargo run --release &' >> start-all.sh && \
     echo 'cd verifier && cargo run --release &' >> start-all.sh && \
-    echo 'cp -r /crescent-credentials/sample/client/dist/* /crescent-credentials/sample/client/extension/' >> start-all.sh && \
-    echo 'cp -r /crescent-credentials/sample/client/mdl.cbor.hex /crescent-credentials/sample/client/extension/' >> start-all.sh && \
+    echo 'cp -r /crescent-credentials/sample/client/dist/* /extension/' >> start-all.sh && \
+    echo 'cp -r /crescent-credentials/sample/client/mdl.cbor.hex /extension/' >> start-all.sh && \
     echo 'wait -n' >> start-all.sh && \
     chmod +x start-all.sh
 
@@ -65,9 +107,3 @@ EXPOSE 8001 8003 8004
 
 CMD ["./start-all.sh"]
 
-# Run with the following commands:
-#   cd crescent-credentials
-#   docker build -f sample/Dockerfile -t crescent-sample .
-#   docker run -v "$(pwd -W)\docker-extension:/crescent-credentials/sample/client/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
-
-# docker run -v "D:\Repos-Temp\crescent-credentials-docker\sample\client\dist:/crescent-credentials/sample/client/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -1,0 +1,73 @@
+FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ROCKET_ADDRESS=0.0.0.0
+
+RUN apt-get update && apt-get upgrade -y && apt-get clean
+RUN apt-get install git curl software-properties-common build-essential python3-pip cmake clang libclang-dev llvm-dev m4 bsdextrautils dos2unix -y
+# RUN { add-apt-repository ppa:git-core/ppa -y; apt update; apt install git -y; git --version; }
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs && node -v && npm -v
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+ENV PATH=/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN pip install --upgrade pip setuptools wheel setuptools-scm
+RUN pip install python_jwt git+https://github.com/peppelinux/pyMDOC-CBOR.git
+
+RUN git clone https://github.com/iden3/circom.git && cd circom && git checkout v2.1.6 && cargo build --release && cargo install --path circom;
+COPY . /crescent-credentials
+RUN find /crescent-credentials -type f -name "*.sh" -exec dos2unix {} +
+
+WORKDIR /crescent-credentials
+RUN git submodule update --init --recursive;
+
+WORKDIR /crescent-credentials/circuit_setup/scripts
+
+RUN ./run_setup.sh rs256
+RUN ./run_setup.sh rs256-sd
+RUN ./run_setup.sh rs256-db
+RUN ./run_setup.sh mdl1
+
+WORKDIR /crescent-credentials/creds
+RUN cargo run --bin crescent --release --features print-trace zksetup --name rs256
+RUN cargo run --bin crescent --release --features print-trace prove --name rs256
+RUN cargo run --bin crescent --release --features print-trace show --name rs256
+RUN cargo run --bin crescent --release --features print-trace verify --name rs256
+
+RUN cargo run --bin crescent --release --features print-trace zksetup --name rs256-sd
+RUN cargo run --bin crescent --release --features print-trace prove --name rs256-sd
+RUN cargo run --bin crescent --release --features print-trace show --name rs256-sd
+RUN cargo run --bin crescent --release --features print-trace verify --name rs256-sd
+
+RUN cargo run --bin crescent --release --features print-trace zksetup --name rs256-db
+RUN cargo run --bin crescent --release --features print-trace prove --name rs256-db
+RUN cargo run --bin crescent --release --features print-trace show --name rs256-db
+RUN cargo run --bin crescent --release --features print-trace verify --name rs256-db
+
+RUN cargo run --bin crescent --release --features print-trace zksetup --name mdl1
+RUN cargo run --bin crescent --release --features print-trace prove --name mdl1
+RUN cargo run --bin crescent --release --features print-trace show --name mdl1
+RUN cargo run --bin crescent --release --features print-trace verify --name mdl1
+
+WORKDIR /crescent-credentials/sample
+RUN ./setup-sample.sh
+RUN echo '#!/bin/bash' > start-all.sh && \
+    # echo 'cd setup_service && cargo run --release &' >> start-all.sh && \
+    echo 'cd client_helper && cargo run --release &' >> start-all.sh && \
+    echo 'cd issuer && cargo run --release &' >> start-all.sh && \
+    echo 'cd verifier && cargo run --release &' >> start-all.sh && \
+    echo 'cp -r /crescent-credentials/sample/client/dist/* /crescent-credentials/sample/client/extension/' >> start-all.sh && \
+    echo 'cp -r /crescent-credentials/sample/client/mdl.cbor.hex /crescent-credentials/sample/client/extension/' >> start-all.sh && \
+    echo 'wait -n' >> start-all.sh && \
+    chmod +x start-all.sh
+
+EXPOSE 8001 8003 8004
+
+CMD ["./start-all.sh"]
+
+# Run with the following commands:
+#   cd crescent-credentials
+#   docker build -f sample/Dockerfile -t crescent-sample .
+#   docker run -v "$(pwd -W)\docker-extension:/crescent-credentials/sample/client/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
+
+# docker run -v "D:\Repos-Temp\crescent-credentials-docker\sample\client\dist:/crescent-credentials/sample/client/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample

--- a/sample/README.md
+++ b/sample/README.md
@@ -19,17 +19,32 @@ Each component must be setup and modified individually; see their respective REA
 
 ## Docker
 
-The sample can be built and run in a docker container without having to install Rust and its dependencies.
-The image build copies the project source code from this directory, so any changes made to the source code will be reflected in the image.
+The sample can be built and run in a docker container without having to install Rust or the project dependencies.
+The docker build copies the project source code from this directory, so any changes made to the source code will be reflected in the image.
 
 ```bash
-# from the root of the project build the image
+# From the root of the project, build the image
 docker build -f sample/Dockerfile -t crescent-sample .
 
-# start the image in a container
-# the browser extension files will be available in the `sample/docker-extension` folder
-docker run -v "$(pwd -W)\docker-extension:/crescent-credentials/sample/client/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
+# Start a container from the image
+# The browser extension files will be available in the `crescent-extension` folder created in the current directory
+
+# Linux
+docker run -v "$(pwd)/crescent-extension:/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
+
+# Windows (Cmd)
+docker run -v "%cd%\crescent-extension:/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
+
+# Windows (Git Bash)
+docker run -v "$(pwd -W)\crescent-extension:/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
 ```
+
+When the container is started, the following services will be available:
+* Issuer: http://localhost:8001
+* Client Helper: http://localhost:8004
+* Verifier: http://localhost:8002
+
+Install the browser extension from the `crescent-extension` folder created in the current directory. See the [client README](./client/README.md#installation) for instructions on how to install the extension.
 
 # Sample Overview
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -17,6 +17,20 @@ Two scripts help with managing the sample projects:
 
 Each component must be setup and modified individually; see their respective README for details. Once setup, follow the instructions from <a href="sample.html">this page</a> to go through the sample demo steps.
 
+## Docker
+
+The sample can be built and run in a docker container without having to install Rust and its dependencies.
+The image build copies the project source code from this directory, so any changes made to the source code will be reflected in the image.
+
+```bash
+# from the root of the project build the image
+docker build -f sample/Dockerfile -t crescent-sample .
+
+# start the image in a container
+# the browser extension files will be available in the `sample/docker-extension` folder
+docker run -v "$(pwd -W)\docker-extension:/crescent-credentials/sample/client/extension" -p 8001:8001 -p 8003:8003 -p 8004:8004 crescent-sample
+```
+
 # Sample Overview
 
 The sample application illustrates the setup of a Crescent system, and the proof generation and verification from a standard JWT or mDL, mimicking a real-life scenario. Note that security aspects have been overly simplified (e.g., using HTTP over localhost instead of HTTPS, simple username/password user authentication, etc.).

--- a/sample/client/package-lock.json
+++ b/sample/client/package-lock.json
@@ -17,7 +17,6 @@
         "@rollup/plugin-virtual": "^3.0.2",
         "@stylistic/eslint-plugin": "^2.8.0",
         "@types/chrome": "0.0.272",
-        "crescent": "file:../../creds/pkg",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
         "eslint": "8.57.1",
@@ -30,15 +29,10 @@
         "typescript": "5.5.4"
       }
     },
-    "../../creds/pkg": {
-      "name": "crescent",
-      "version": "0.5.0",
-      "dev": true
-    },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.0.tgz",
+      "integrity": "sha512-WhCn7Z7TauhBtmzhvKpoQs0Wwb/kBcy4CwpuI0/eEIr2Lx2auxmulAzLr91wVZJaz47iUZdkXOK7WlAfxGKCnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -300,9 +294,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.0.tgz",
+      "integrity": "sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -804,9 +798,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -870,13 +864,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -894,17 +888,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.0.tgz",
-      "integrity": "sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.30.1.tgz",
+      "integrity": "sha512-v+VWphxMjn+1t48/jO4t950D6KR8JaJuNXzi33Ve6P8sEmPr5k6CEXjdGwT6+LodVnEa91EQCtwjWNUCPweo+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.26.0",
-        "@typescript-eslint/type-utils": "8.26.0",
-        "@typescript-eslint/utils": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0",
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/type-utils": "8.30.1",
+        "@typescript-eslint/utils": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -924,16 +918,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.0.tgz",
-      "integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.30.1.tgz",
+      "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.26.0",
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/typescript-estree": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0",
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/typescript-estree": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -949,14 +943,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz",
-      "integrity": "sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.30.1.tgz",
+      "integrity": "sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0"
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -967,14 +961,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.0.tgz",
-      "integrity": "sha512-ruk0RNChLKz3zKGn2LwXuVoeBcUMh+jaqzN461uMMdxy5H9epZqIBtYj7UiPXRuOpaALXGbmRuZQhmwHhaS04Q==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.30.1.tgz",
+      "integrity": "sha512-64uBF76bfQiJyHgZISC7vcNz3adqQKIccVoKubyQcOnNcdJBvYOILV1v22Qhsw3tw3VQu5ll8ND6hycgAR5fEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.26.0",
-        "@typescript-eslint/utils": "8.26.0",
+        "@typescript-eslint/typescript-estree": "8.30.1",
+        "@typescript-eslint/utils": "8.30.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.1"
       },
@@ -991,9 +985,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.0.tgz",
-      "integrity": "sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.30.1.tgz",
+      "integrity": "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1005,14 +999,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz",
-      "integrity": "sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.30.1.tgz",
+      "integrity": "sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1032,16 +1026,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.0.tgz",
-      "integrity": "sha512-2L2tU3FVwhvU14LndnQCA2frYC8JnPDVKyQtWFPf8IYFMt/ykEN1bPolNhNbCVgOmdzTlWdusCTKA/9nKrf8Ig==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.30.1.tgz",
+      "integrity": "sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.26.0",
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/typescript-estree": "8.26.0"
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/typescript-estree": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1056,13 +1050,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz",
-      "integrity": "sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.30.1.tgz",
+      "integrity": "sha512-aEhgas7aJ6vZnNFC7K4/vMGDGyOiqWcYZPpIWrTKuTAlsvDNKy2GFDqh9smL+iq069ZvR0YzEeq0B8NJlLzjFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.0",
+        "@typescript-eslint/types": "8.30.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -1202,18 +1196,19 @@
       }
     },
     "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
-      "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1470,10 +1465,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/crescent": {
-      "resolved": "../../creds/pkg",
-      "link": true
-    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -1660,9 +1651,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -2121,13 +2112,13 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "17.16.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.16.2.tgz",
-      "integrity": "sha512-iQM5Oj+9o0KaeLoObJC/uxNGpktZCkYiTTBo8PkRWq3HwNcRxwpvSDFjBhQ5+HLJzBTy+CLDC5+bw0Z5GyhlOQ==",
+      "version": "17.17.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.17.0.tgz",
+      "integrity": "sha512-2VvPK7Mo73z1rDFb6pTvkH6kFibAmnTubFq5l83vePxu0WiY1s0LOtj2WHb6Sa40R3w4mnh8GFYbHBQyMlotKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.1",
+        "@eslint-community/eslint-utils": "^4.5.0",
         "enhanced-resolve": "^5.17.1",
         "eslint-plugin-es-x": "^7.8.0",
         "get-tsconfig": "^4.8.1",
@@ -3472,33 +3463,33 @@
       }
     },
     "node_modules/lit": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
-      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
+      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.1.0",
-        "lit-html": "^3.2.0"
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
-      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.0.tgz",
+      "integrity": "sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.2.0"
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
-      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.0.tgz",
+      "integrity": "sha512-RHoswrFAxY2d8Cf2mm4OZ1DgzCoBKUKSPvA1fhtSELxUERq2aQQ2h05pO9j81gS1o7RIRJ+CePLogfyahwmynw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4792,9 +4783,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4943,15 +4934,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.26.0.tgz",
-      "integrity": "sha512-PtVz9nAnuNJuAVeUFvwztjuUgSnJInODAUx47VDwWPXzd5vismPOtPtt83tzNXyOjVQbPRp786D6WFW/M2koIA==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.30.1.tgz",
+      "integrity": "sha512-D7lC0kcehVH7Mb26MRQi64LMyRJsj3dToJxM1+JVTl53DQSV5/7oUGWQLcKl1C1KnoVHxMMU2FNQMffr7F3Row==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.26.0",
-        "@typescript-eslint/parser": "8.26.0",
-        "@typescript-eslint/utils": "8.26.0"
+        "@typescript-eslint/eslint-plugin": "8.30.1",
+        "@typescript-eslint/parser": "8.30.1",
+        "@typescript-eslint/utils": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4985,9 +4976,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5095,16 +5086,17 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },

--- a/sample/client/package.json
+++ b/sample/client/package.json
@@ -24,7 +24,6 @@
     "@rollup/plugin-virtual": "^3.0.2",
     "@stylistic/eslint-plugin": "^2.8.0",
     "@types/chrome": "0.0.272",
-    "crescent": "file:../../creds/pkg",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
     "eslint": "8.57.1",

--- a/sample/client/setup_client.sh
+++ b/sample/client/setup_client.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Define the source and target directories as arrays
-CRESCENT_DIR=("../../creds")
+CRESCENT_DIR="../../creds"
 
 # Make sure we're in the right directory
 CURRENT_DIR=${PWD##*/}
@@ -14,19 +14,20 @@ fi
 echo "Building crescent wasm package"
 pushd $CRESCENT_DIR > /dev/null
 cargo install wasm-pack
+
+# Build crescent wasm package 
 RUSTFLAGS="-A unused-imports -A unused-assignments -A unused-variables" \
-wasm-pack build --target web --no-default-features --features wasm
+wasm-pack build --target web --no-default-features --features wasm || \
+echo -e "\n\033[33m[WARNING] wasm-pack build failed. Proceeding without it.\033[0m\n"
 
-if [ $? -ne 0 ]; then
-    echo "[WARNING] wasm-pack build failed. Proceeding without it."
-fi
-
-## Alternative way to build wasm package with temp install of wasm-pack but slower as it builds each time
-# TMP_DIR="$(mktemp -d)"
-# cargo install --root "$TMP_DIR" wasm-pack
-# "$TMP_DIR/bin/wasm-pack" build --target web --no-default-features --features wasm
-# rm -rf "$TMP_DIR"
+popd > /dev/null
 
 echo "Install NPM dependencies"
-popd > /dev/null
 npm install
+
+if [ -f "$CRESCENT_DIR/pkg/package.json" ]; then
+    echo "Installing NPM dependencies for crescent"
+    npm install -D ../../creds/pkg/    
+else
+    echo -e "\n\033[33m[WARNING]No package.json found in ../../creds/pkg. Skipping NPM install.\033[0m\n"
+fi

--- a/sample/client/src/cred.ts
+++ b/sample/client/src/cred.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT license.
  */
 
-import { fields as mdocFields } from './mdoc'
+import { type mdocDocument, fields as mdocFields } from './mdoc'
 import { fields as jwtFields } from './jwt'
 import schemas, { type Schema } from './schema'
 import type { CardElement } from './components/card'
@@ -20,7 +20,7 @@ export interface CredentialRecord {
     type: 'JWT' | 'MDOC'
     schema: string
     raw: string
-    value: JWT_TOKEN | MDOC
+    value: JWT_TOKEN | mdocDocument
     fields: Record<string, unknown>
   }
   issuer: {
@@ -92,7 +92,7 @@ export class Credential {
         schema: schema.name,
         raw: rawJwtOrMdoc,
         value: decoded.value,
-        fields: schema.type === 'JWT' ? jwtFields(decoded.value as JWT_TOKEN) : mdocFields(decoded.value as MDOC)
+        fields: schema.type === 'JWT' ? jwtFields(decoded.value as JWT_TOKEN) : mdocFields(decoded.value as mdocDocument)
       },
       issuer: {
         url: credentialOrDomain.startsWith('http') ? credentialOrDomain : `http://${credentialOrDomain}`,


### PR DESCRIPTION
Added a `Dockerfile` in the `sample` folder to build and run the Crescent sample in a docker container

- All the project dependencies are installed in the docker image.
- The Crescent source for the image is copied from the local directory at build time, so any changes to the source code will be reflected in the resulting docker image.
- Circom is cloned from its repo and is not copied from the local machine.
- When running the container, the Crescent services will start and be available using the default endpoints. The ports can be changed as parameters to the run command.
- The container will mount a folder called `crescent-extention` to the local directory that contains the client extension files and the mdl sample file.
- The image build can take 30+ minutes to generate and use 35+GB of disk space.
- Once the image is available, the container can be run with the `docker run` command.
- Updated `sample/README.md` to add Docker info.
- The `Dockerfile` itself contains comments to help build and run.