### PR TITLE
added missing range checks in RemoveValue template

### DIFF
--- a/circuit_setup/circuits/utils/jwt.circom
+++ b/circuit_setup/circuits/utils/jwt.circom
@@ -162,13 +162,16 @@ template NumPaddingBytes(n) {
 //    The resulting buffer will have length n - 1, but padded with zeros to n.
 //    E.g.:    input: [a, b, c, d, e, f], p = 2
 //             output: [a, b, d, e, f, 0]
-//    Assumes p < 2^15
+//    Assumes p < 2^15, which is checked in this template via Num2Bits.
 template RemoveValue(n) {
     signal input in[n];
     signal output out[n];
     signal input p;
 
-    assert(p < 32768);
+    // Range-checking `p` to ensure it is less than 2^15.
+    // This is required by GreaterEqThan(15).
+    component p_bits = Num2Bits(15);
+    p_bits.in <== p;
 
     component cmp[n];
     signal normal_branch[n];


### PR DESCRIPTION
This pull request adds a missing range check in the `RemoveValue` template to address the vulnerability described in the following issue:

* \#128
  The template uses the `GreaterEqThan(15)` comparator to determine whether an index `i` is greater than or equal to a given position `p`. However, `GreaterEqThan(n)` (which internally uses `LessThan(n)`) assumes that its inputs are bounded to `n` bits and does not enforce this constraint. The existing `assert(p < 32768)` is just a compile-time check, which is ignored by the verifier.

Without an explicit range check, a malicious prover can supply an out-of-range field element (e.g., `p − 1`) that wraps modulo the field prime and still satisfies the comparator logic due to overflow, leading to incorrect circuit behaviour.

To fix this, we replace the `assert` with a proper `Num2Bits(15)` constraint.

Closes #128.