### PR TITLE
fix: add support for macos in cert chain script

### DIFF
--- a/circuit_setup/scripts/gen_x509_cert_chain.sh
+++ b/circuit_setup/scripts/gen_x509_cert_chain.sh
@@ -12,9 +12,10 @@ export MSYS_NO_PATHCONV=1
 
 # directory where intermediate files are kept
 tmpdir=../generated_files/mdl1
-# force relative paths that will work with openssl on both linux and windows.
-scriptsdir=$(realpath --relative-to=$tmpdir $(pwd)) 
-outdir=$(realpath --relative-to=$tmpdir ../inputs/mdl1) 
+# force relative paths that will work with openssl on both linux, windows, and macOS.
+current_dir=$(pwd)
+scriptsdir=$(realpath "$current_dir")
+outdir=$(realpath ../inputs/mdl1)
 mkdir -p "$tmpdir"
 cd "$tmpdir" || exit 1
 

--- a/circuit_setup/scripts/gen_x509_cert_chain.sh
+++ b/circuit_setup/scripts/gen_x509_cert_chain.sh
@@ -12,7 +12,7 @@ export MSYS_NO_PATHCONV=1
 
 # directory where intermediate files are kept
 tmpdir=../generated_files/mdl1
-# force relative paths that will work with openssl on both linux, windows, and macOS.
+# force relative paths that will work with openssl on linux, windows, and macOS.
 current_dir=$(pwd)
 scriptsdir=$(realpath "$current_dir")
 outdir=$(realpath ../inputs/mdl1)


### PR DESCRIPTION
This gets the setup scripts working on a (my) macOS machine.

I have NOT tested this change on Linux and Windows - these changes should be tested on those environments before merging this PR.