### PR TITLE
Fix new clippy failures from rust update

### DIFF
--- a/circuit_setup/mdl-tools/src/bin/mdl-gen.rs
+++ b/circuit_setup/mdl-tools/src/bin/mdl-gen.rs
@@ -71,7 +71,7 @@ fn mdoc_builder(claims: String, device_priv_key: String) -> Builder {
 
     // Handle the ISO MDL namespace
     let isomdl_claims = parsed.get(ISO_MDL_NAMESPACE)
-        .ok_or_else(|| format!("Missing key: {}", ISO_MDL_NAMESPACE))
+        .ok_or_else(|| format!("Missing key: {ISO_MDL_NAMESPACE}"))
         .unwrap();
     let isomdl_data = OrgIso1801351::from_json(isomdl_claims)
         .unwrap()

--- a/circuit_setup/mdl-tools/src/bin/prepare-prover-input.rs
+++ b/circuit_setup/mdl-tools/src/bin/prepare-prover-input.rs
@@ -263,7 +263,7 @@ fn find_element_positions(preimage: &[u8], identifier: &str) -> Option<(usize, u
 
     let value_l = element_value_pos + element_value_label.len();
     let value_r = preimage.len();
-    println!("identifier_l: {}, identifier_r: {}, value_l: {}, value_r: {}", identifier_l, identifier_r, value_l, value_r);
+    println!("identifier_l: {identifier_l}, identifier_r: {identifier_r}, value_l: {value_l}, value_r: {value_r}");
     Some((identifier_l, identifier_r, value_l, value_r))
 }
 
@@ -273,7 +273,7 @@ fn extract_text(value: Value) -> String {
         Value::Tag(_, boxed) => extract_text(*boxed),
         Value::Text(s) => s,
         Value::Integer(i) => i128::from(i).to_string(),
-        other => panic!("Expected Text, Integer, or Tag containing Text/Integer, got {:?}", other),
+        other => panic!("Expected Text, Integer, or Tag containing Text/Integer, got {other:?}"),
     }
 }
 
@@ -306,8 +306,8 @@ pub(crate) fn find_value_digest_info(
                 if item.as_ref().element_identifier != claim {
                     continue;
                 }
-                println!("found claim: {}", claim);
-                println!("item: {:?}", item);
+                println!("found claim: {claim}");
+                println!("item: {item:?}");
 
                 info.value = extract_text(item.as_ref().element_value.clone());
                 println!("value: {:?}", info.value);
@@ -325,7 +325,7 @@ pub(crate) fn find_value_digest_info(
                 // print recomputed digest as hex
                 println!("Recomputed digest: {}", hex::encode(&recomputed_value_digest));
                 let ns_digests = mso.value_digests.get(ns)
-                    .ok_or(format!("Namespace {} not found", ns)).unwrap();
+                    .ok_or(format!("Namespace {ns} not found")).unwrap();
                 let signed_value_digest = ns_digests.get(&info.id)
                     .ok_or(format!("Signed value digest not found for digest id {:?}", info.id)).unwrap();
                 println!("signed_value_digest: {:?}", hex::encode(signed_value_digest));
@@ -347,7 +347,7 @@ pub(crate) fn find_value_digest_info(
         }
     }
     
-    println!("Claim not found: {}", claim);
+    println!("Claim not found: {claim}");
     None
 }
 
@@ -356,19 +356,19 @@ fn check_config(config: &serde_json::Map<String, serde_json::Value>) {
     // check the credtype
     let credtype = config["credtype"].as_str().unwrap();
     if credtype != "mdl" {
-        panic!("Invalid credtype: {}", credtype);
+        panic!("Invalid credtype: {credtype}");
     }
 
     // check the signature alg
     let alg = config["alg"].as_str().unwrap();
     if alg != "ES256" {
-        panic!("Unsupported alg: {}", alg);
+        panic!("Unsupported alg: {alg}");
     }
 
     // make sure max_cred_len exists
     let max_cred_len = config["max_cred_len"].as_u64().unwrap();
     if max_cred_len == 0 {
-        panic!("Invalid max_cred_len, needs to be > 0: {}", max_cred_len);
+        panic!("Invalid max_cred_len, needs to be > 0: {max_cred_len}");
     }
 }
 
@@ -379,7 +379,7 @@ fn pack_string_to_int_unquoted(s: &str, n_bytes: usize) -> Result<String, Box<st
     //First convert "s" to bytes and pad with zeros
     let s_bytes = s.bytes();
     if s_bytes.len() > n_bytes {
-        panic!("String to large to convert to integer of n_bytes = {}", n_bytes);
+        panic!("String to large to convert to integer of n_bytes = {n_bytes}");
     }
     let mut s_bytes = s_bytes.collect::<Vec<u8>>();
     for _ in 0 .. n_bytes - s_bytes.len() {
@@ -413,9 +413,9 @@ fn main() {
         .unwrap();
 
     let doc_type = mdoc.doc_type;
-    println!("doc_type: {}\n", doc_type);
+    println!("doc_type: {doc_type}\n");
     if doc_type != MDL_DOCTYPE {
-        panic!("Invalid mDL doc type: {}", doc_type);
+        panic!("Invalid mDL doc type: {doc_type}");
     }
     
     let mso = mdoc.mso;
@@ -430,7 +430,7 @@ fn main() {
     let namespaces = mdoc.namespaces;
     for (key, value) in namespaces.iter() {
         if !SUPPORTED_NAMESPACES.contains(&key.as_str()) {
-            panic!("Invalid mDL namespace: {}", key);
+            panic!("Invalid mDL namespace: {key}");
         }
         println!("{} namespace claim count: {}\n", key, value.len());
     }
@@ -464,7 +464,7 @@ fn main() {
     // convert header and payload to UTF-8 integers in base-10 (e.g., 'e' -> 101, 'y' -> 121, ...)
     let padded_m = sha256_padding(&tbs_data_ints);
     let msg_len_after_sha2_padding = padded_m.len();
-    println!("msg_len_after_SHA2_padding: {:?}\n", msg_len_after_sha2_padding);
+    println!("msg_len_after_SHA2_padding: {msg_len_after_sha2_padding:?}\n");
 
     let config_max_cred_len = config["max_cred_len"].as_u64().unwrap() as usize;
     if tbs_data_ints.len() > config_max_cred_len {
@@ -491,7 +491,7 @@ fn main() {
     let valid_until_pos = valid_until_prefix_pos + valid_until_prefix.len();
     let valid_until_data = &tbs_data_hex[valid_until_pos..valid_until_pos + 40];
     let valid_until_unix_timestamp = ymd_to_timestamp(valid_until_data, true, true).unwrap();
-    println!("valid_until_unix_timestamp: {}", valid_until_unix_timestamp);
+    println!("valid_until_unix_timestamp: {valid_until_unix_timestamp}");
     
     // begin output of prover and auxiliary inputs
     let mut prover_inputs = Map::new();
@@ -510,32 +510,32 @@ fn main() {
             continue;
         }
         let claim_name = key.as_str();
-        let entry = config[claim_name].as_object().ok_or(format!("Config file entry for claim {}, does not have object type", claim_name)).unwrap();
-        let claim_type = entry["type"].as_str().ok_or(format!("Config file entry for claim {}, is missing 'type'", claim_name)).unwrap();
+        let entry = config[claim_name].as_object().ok_or(format!("Config file entry for claim {claim_name}, does not have object type")).unwrap();
+        let claim_type = entry["type"].as_str().ok_or(format!("Config file entry for claim {claim_name}, is missing 'type'")).unwrap();
         let reveal = entry.get("reveal").and_then(|v| v.as_bool()).unwrap_or(false);
         let reveal_digest = entry.get("reveal_digest").and_then(|v| v.as_bool()).unwrap_or(false);
-        let max_claim_byte_len = entry["max_claim_byte_len"].as_u64().ok_or(format!("Config file entry for claim {} does not have a valid u64 'max_claim_byte_len'", claim_name)).map(|v| v as usize).unwrap();
+        let max_claim_byte_len = entry["max_claim_byte_len"].as_u64().ok_or(format!("Config file entry for claim {claim_name} does not have a valid u64 'max_claim_byte_len'")).map(|v| v as usize).unwrap();
 
         if !reveal && !reveal_digest {
-            println!("Claim {} is not revealed or reveal_digest: skipping", claim_name);
+            println!("Claim {claim_name} is not revealed or reveal_digest: skipping");
             continue;
         }
 
         println!("\nProcessing {} ({}) for {}", claim_name, claim_type, if reveal { "reveal" } else { "reveal_digest" });
 
         let claim_info = find_value_digest_info(&namespaces, &mso, &tbs_data, claim_name).unwrap();
-        println!("claim_info ({}): {:?}", claim_name, claim_info);
-        prover_inputs.insert(format!("{}_id", claim_name).to_string(), serde_json::json!(claim_info.id));
+        println!("claim_info ({claim_name}): {claim_info:?}");
+        prover_inputs.insert(format!("{claim_name}_id").to_string(), serde_json::json!(claim_info.id));
         let claim_value_str = claim_info.value.as_str();
 
         let claim_preimage = sha256_padding(claim_info.preimage.as_ref());
         if claim_preimage.len() != 128 { // FIXME: don't hardcode this value. Currently correct for the mDL we generate, but not in general
             panic!("Invalid {}_preimage length: {}; expected 128 (hardcoded in circom circuit)", claim_name, claim_preimage.len());
         }
-        prover_inputs.insert(format!("{}_preimage", claim_name).to_string(), serde_json::json!(claim_preimage));
-        prover_inputs.insert(format!("{}_encoded_l", claim_name).to_string(), serde_json::json!(claim_info.encoded_l));
-        prover_inputs.insert(format!("{}_encoded_r", claim_name).to_string(), serde_json::json!(claim_info.encoded_r));
-        prover_inputs.insert(format!("{}_identifier_l", claim_name).to_string(), serde_json::json!(claim_info.identifier_l));
+        prover_inputs.insert(format!("{claim_name}_preimage").to_string(), serde_json::json!(claim_preimage));
+        prover_inputs.insert(format!("{claim_name}_encoded_l").to_string(), serde_json::json!(claim_info.encoded_l));
+        prover_inputs.insert(format!("{claim_name}_encoded_r").to_string(), serde_json::json!(claim_info.encoded_r));
+        prover_inputs.insert(format!("{claim_name}_identifier_l").to_string(), serde_json::json!(claim_info.identifier_l));
 
         if reveal {
             match claim_type {
@@ -543,23 +543,23 @@ fn main() {
                     // for string values, we skip the first CBOR byte (0x60) which indicates the string length, to only compare the claim value
                     // FIXME: not true in general, only for short strings!
                     let value_l = claim_info.value_l + 1;
-                    prover_inputs.insert(format!("{}_value_l", claim_name).to_string(), serde_json::json!(value_l));
-                    prover_inputs.insert(format!("{}_value_r", claim_name).to_string(), serde_json::json!(claim_info.value_r));
+                    prover_inputs.insert(format!("{claim_name}_value_l").to_string(), serde_json::json!(value_l));
+                    prover_inputs.insert(format!("{claim_name}_value_r").to_string(), serde_json::json!(claim_info.value_r));
                     let claim_value = pack_string_to_int_unquoted(claim_value_str, max_claim_byte_len).unwrap();
-                    prover_inputs.insert(format!("{}_value", claim_name).to_string(), serde_json::json!(claim_value));
+                    prover_inputs.insert(format!("{claim_name}_value").to_string(), serde_json::json!(claim_value));
                 },
                 "date" => {
                     // we don't need the value_l and value_r for date
                     let claim_value = ymd_to_daystamp(claim_value_str).unwrap();
-                    prover_inputs.insert(format!("{}_value", claim_name).to_string(), serde_json::json!(claim_value));
+                    prover_inputs.insert(format!("{claim_name}_value").to_string(), serde_json::json!(claim_value));
                 },
                 "integer" => {
                     // encode integer directly
-                    prover_inputs.insert(format!("{}_value", claim_name).to_string(), serde_json::json!(claim_value_str));
+                    prover_inputs.insert(format!("{claim_name}_value").to_string(), serde_json::json!(claim_value_str));
                 },
                 // TODO: add support for other claim types
                 &_ => {
-                    panic!("Unsupported claim type: {}", claim_type);
+                    panic!("Unsupported claim type: {claim_type}");
                 }
             };
         } else if reveal_digest {
@@ -575,8 +575,8 @@ fn main() {
                         // for string values, we skip the first CBOR byte (0x60) which indicates the string length, to only compare the claim value
                         // FIXME: not true in general, only for short strings!
                         let value_l = claim_info.value_l + 1;
-                        prover_inputs.insert(format!("{}_value_l", claim_name).to_string(), serde_json::json!(value_l));
-                        prover_inputs.insert(format!("{}_value_r", claim_name).to_string(), serde_json::json!(claim_info.value_r));
+                        prover_inputs.insert(format!("{claim_name}_value_l").to_string(), serde_json::json!(value_l));
+                        prover_inputs.insert(format!("{claim_name}_value_r").to_string(), serde_json::json!(claim_info.value_r));
                         prover_aux.insert(claim_name.to_string(), serde_json::json!(claim_value_str));
                     }
                     _ => {
@@ -603,7 +603,7 @@ fn main() {
     // this code assumes |R|==|S|
     let sig_len = signature_bytes.len();
     if sig_len % 2 != 0 {
-        panic!("Invalid signature length: {}", sig_len);
+        panic!("Invalid signature length: {sig_len}");
     }
     // signature is not required by the circuit, but it is required for the signature verification pre-computations
     // by the precompEcdsa script. That script extracts the signature from the prover_input.json file.
@@ -624,7 +624,7 @@ fn main() {
     prover_inputs.insert("pubkey_hash".to_string(), serde_json::json!(pubkey_hash.to_str_radix(10)));
 
     prover_inputs.insert("message_bytes".to_string(), tbs_data_ints.len().into());
-    println!("Number of SHA blocks to hash: {}\n", msg_len_after_sha2_padding);
+    println!("Number of SHA blocks to hash: {msg_len_after_sha2_padding}\n");
 
     // If device bound, include the device public key in the prover inputs
     if config["device_bound"].as_bool().is_some_and(|x| x) {
@@ -635,8 +635,8 @@ fn main() {
             CoseKey::EC2 { x, y, .. } => (x, y),
             _ => panic!("Unsupported curve type, expected EC2 (https://www.rfc-editor.org/rfc/rfc9053.html#name-elliptic-curve-keys)")
         };
-        println!("device_key.x = {:?}", device_key_x);
-        println!("device_key.y = {:?}", device_key_y);
+        println!("device_key.x = {device_key_x:?}");
+        println!("device_key.y = {device_key_y:?}");
         prover_inputs.insert("device_key_x".to_string(), serde_json::json!(device_key_x));
         // device_key_x is Vec<u8>, device_key_y is EC2Y
         let device_pub_key_x = BigUint::from_bytes_be(&device_key_x);
@@ -660,8 +660,8 @@ fn main() {
 
         let device_key_0 = bytes_to_int(&device_key_x[0..16]);
         let device_key_1 = bytes_to_int(&device_key_x[16..32]);
-        println!("device_key_0_value: {:?}", device_key_0);
-        println!("device_key_1_value: {:?}", device_key_1);
+        println!("device_key_0_value: {device_key_0:?}");
+        println!("device_key_1_value: {device_key_1:?}");
         prover_inputs.insert("device_key_0_value".to_string(), serde_json::json!(device_key_0));
         prover_inputs.insert("device_key_1_value".to_string(), serde_json::json!(device_key_1));
 
@@ -696,7 +696,7 @@ fn main() {
 
     // save the auxiliary data to a file
     let prover_aux_json = serde_json::to_string_pretty(&prover_aux).unwrap();
-    println!("Prover auxiliary data: {}", prover_aux_json);
+    println!("Prover auxiliary data: {prover_aux_json}");
     println!("output file: {}", args.prover_aux);
     std::fs::write(&args.prover_aux, prover_aux_json).unwrap();
     println!("Prover auxiliary data saved to: {}\n", args.prover_aux);

--- a/creds/src/bin/proverinput.rs
+++ b/creds/src/bin/proverinput.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Claims:");
     if let Value::Object(map) = claims.clone() {
         for (k, v) in map {
-            println!("{} : {}", k, v);
+            println!("{k} : {v}");
         }
     } else {
         panic!("Claims are not a JSON object");

--- a/creds/src/daystamp.rs
+++ b/creds/src/daystamp.rs
@@ -36,7 +36,7 @@ fn days_before_month(year: usize, month: usize) -> usize {
 fn ymd_to_ordinal(year: usize, month: usize, day: usize) -> usize {
     assert!((1..=12).contains(&month), "month must be in 1..12");
     let dim = days_in_month(year, month);
-    assert!(1 <= day && day <= dim, "day must be in 1..{}", dim);
+    assert!(1 <= day && day <= dim, "day must be in 1..{dim}");
     days_before_year(year) + days_before_month(year, month) + day
 }  
 
@@ -58,7 +58,7 @@ pub fn days_to_be_age(age: u64) -> usize {
     let past_stamp = ymd_to_ordinal(year - age as usize, month, day);
 
     assert!(today_stamp > past_stamp);
-    println!("To be {} years old, you must be {} days old", age, today_stamp - past_stamp);
+    println!("To be {age} years old, you must be {} days old", today_stamp - past_stamp);
 
     today_stamp - past_stamp
 }

--- a/creds/src/dlog.rs
+++ b/creds/src/dlog.rs
@@ -133,7 +133,7 @@ impl<G: Group> DLogPoK<G> {
 
         let mut recomputed_k = Vec::new();
         for i in 0..y.len() {
-            assert_eq!(bases[i].len(), self.s[i].len(), "i: {}", i);
+            assert_eq!(bases[i].len(), self.s[i].len(), "i: {i}");
             let mut bases_affine : Vec<G::Affine> = bases[i].iter().map(|x| x.into_affine()).collect();
             bases_affine.push(y[i].into_affine());
             let mut scalars = vec![];
@@ -202,8 +202,7 @@ impl<G: Group> DLogPoK<G> {
         let mut bases_g: Vec<G::Affine> = Vec::new();
         for i in 1..3 {
             bases_g.push(hash_to_curve_vartime::<G>(&format!(
-                "Pedersen commitment base {}",
-                i
+                "Pedersen commitment base {i}"
             )));
         }
         bases_g

--- a/creds/src/groth16rand.rs
+++ b/creds/src/groth16rand.rs
@@ -291,7 +291,7 @@ impl<E: Pairing> ShowGroth16<E> {
         let groth16_valid = match groth16_result {
             Ok(b) => b, 
             Err(e) => {
-                println!("Failed to verify Groth16 proof with error: {:?}", e);
+                println!("Failed to verify Groth16 proof with error: {e:?}");
                 false
             }
         };

--- a/creds/src/main.rs
+++ b/creds/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
 
     match opt.cmd {
         Command::Zksetup{ name } => {
-            let name_path = format!("test-vectors/{}", name);
+            let name_path = format!("test-vectors/{name}");
             let base_path = root.join(name_path);
             let ret = run_zksetup(base_path);
             if ret == 0 {
@@ -32,17 +32,17 @@ fn main() {
             }
         }
         Command::Prove { name } | Command::Prepare { name } => {
-            let name_path = format!("test-vectors/{}", name);
+            let name_path = format!("test-vectors/{name}");
             let base_path = root.join(name_path);
             run_prover(base_path);
         }
         Command::Show { name, presentation_message } => {
-            let name_path = format!("test-vectors/{}", name);
+            let name_path = format!("test-vectors/{name}");
             let base_path = root.join(name_path);
             run_show(base_path, presentation_message);
         }        
         Command::Verify { name, presentation_message } => {
-            let name_path = format!("test-vectors/{}", name);
+            let name_path = format!("test-vectors/{name}");
             let base_path = root.join(name_path);
             run_verifier(base_path, presentation_message);
         }
@@ -97,7 +97,7 @@ pub fn run_prover(
     base_path: PathBuf,
 ) {
     let paths = CachePaths::new(base_path);
-    let config_str = fs::read_to_string(&paths.config).unwrap_or_else(|_| panic!("Unable to read config from {} ", paths.config));
+    let config_str = fs::read_to_string(&paths.config).unwrap_or_else(|_| panic!("Unable to read config from {}", paths.config));
     let config = parse_config(&config_str).expect("Failed to parse config");
 
     let client_state = 
@@ -108,7 +108,7 @@ pub fn run_prover(
     }
     else {
         let jwt = fs::read_to_string(&paths.jwt).unwrap_or_else(|_| panic!("Unable to read JWT file from {}", paths.jwt));
-        let issuer_pem = fs::read_to_string(&paths.issuer_pem).unwrap_or_else(|_| panic!("Unable to read issuer public key PEM from {} ", paths.issuer_pem));   
+        let issuer_pem = fs::read_to_string(&paths.issuer_pem).unwrap_or_else(|_| panic!("Unable to read issuer public key PEM from {}", paths.issuer_pem));   
         let device_pub_pem = fs::read_to_string(&paths.device_pub_pem).ok();
         let (prover_inputs_json, prover_aux_json, _public_ios_json) = 
             prepare_prover_inputs(&config, &jwt, &issuer_pem, device_pub_pem.as_deref()).expect("Failed to prepare prover inputs");    
@@ -123,15 +123,15 @@ pub fn run_prover(
 fn _show_groth16_proof_size(show_groth16: &ShowGroth16<CrescentPairing>) -> usize {
     print!("Show_Groth16 proof size: ");
     let rand_proof_size = show_groth16.rand_proof.compressed_size();
-    print!("{} (rand_proof) + ", rand_proof_size);
+    print!("{rand_proof_size} (rand_proof) + ");
     let com_hidden_inputs_size = show_groth16.com_hidden_inputs.compressed_size();
-    print!("{} (com_hidden_inputs) + ", com_hidden_inputs_size);
+    print!("{com_hidden_inputs_size} (com_hidden_inputs) + ");
     let pok_inputs_size = show_groth16.pok_inputs.compressed_size();
-    print!("{} (pok_inputs) + ", pok_inputs_size);
+    print!("{pok_inputs_size} (pok_inputs) + ");
     let committed_inputs_size = show_groth16.commited_inputs.compressed_size();
-    print!("{} (committed_inputs) ", committed_inputs_size);
+    print!("{committed_inputs_size} (committed_inputs) ");
     let total = rand_proof_size + com_hidden_inputs_size + pok_inputs_size + committed_inputs_size;
-    println!(" = {} bytes total", total);
+    println!(" = {total} bytes total");
     total
 }
 
@@ -139,44 +139,44 @@ fn show_proof_size(show_proof: &ShowProof<CrescentPairing>) -> usize {
 
     print!("Show proof size: ");
     let groth16_size = show_proof.show_groth16.compressed_size();
-    print!("{} (Groth16 proof) + ", groth16_size);
+    print!("{groth16_size} (Groth16 proof) + ");
     let show_range_size = show_proof.show_range_exp.compressed_size();
-    print!("{} (range proof) ", show_range_size);
+    print!("{show_range_size} (range proof) ");
 
     // accumulate the size of the show_range_attr proofs
     let mut show_range_attr_size = 0;
     for (i, show_range_attr) in show_proof.show_range_attr.iter().enumerate() {
         let tmp = show_range_attr.compressed_size();
-        print!(" + {} (range proof{}) ", tmp, i);
+        print!(" + {tmp} (range proof{i}) ");
         show_range_attr_size += tmp;
     }
 
     let device_proof_size = if show_proof.device_proof.is_some() {
         let tmp = show_proof.device_proof.compressed_size();
-        print!("+ {} (device signature proof)", tmp);
+        print!("+ {tmp} (device signature proof)");
         tmp
     } else {
         0
     };
 
     let total = groth16_size + show_range_size + show_range_attr_size + device_proof_size;
-    println!(" = {} bytes total", total);
+    println!(" = {total} bytes total");
 
     total
 }
 
 fn load_proof_spec(proof_spec_file_path : &str, presentation_message: Option<String>) -> ProofSpec {
     let ps_raw = if PathBuf::from(proof_spec_file_path).exists() {
-        println!("Using proof spec file {}", proof_spec_file_path);
+        println!("Using proof spec file {proof_spec_file_path}");
         fs::read_to_string(proof_spec_file_path).expect("Proof spec file exists, but failed while reading it")
     } else {
-        println!("Proof spec file not found; using default (looked for file: {}) ", proof_spec_file_path);
+        println!("Proof spec file not found; using default (looked for file: {proof_spec_file_path}) ");
         crescent::DEFAULT_PROOF_SPEC.to_string()
     };
     let mut ps : ProofSpec = serde_json::from_str(&ps_raw).unwrap();
 
     if ps.presentation_message.is_some() && presentation_message.is_some() {
-        println!("Error: presentation message was provided twice, once in the proof specification file ({}) and once as a command line option.", proof_spec_file_path);
+        println!("Error: presentation message was provided twice, once in the proof specification file ({proof_spec_file_path}) and once as a command line option.");
         panic!("Multiple presentation messages");
     }
     if presentation_message.is_some() {
@@ -239,7 +239,7 @@ pub fn run_verifier(base_path: PathBuf, presentation_message: Option<String>) {
     
     let (verify_result, data) = verify_show(&vp, &show_proof, &proof_spec);
     if verify_result {
-        println!("Verify succeeded, got data '{}'", data);
+        println!("Verify succeeded, got data '{data}'");
     }
     else {
         println!("Verify failed")

--- a/creds/src/rangeproof.rs
+++ b/creds/src/rangeproof.rs
@@ -385,7 +385,7 @@ impl<E: Pairing> RangeProof<E> {
                 return false;
             },
             Err(ret) => {
-                println!("Error verifying range proof, batch_check failed with error: {:?} ", ret);
+                println!("Error verifying range proof, batch_check failed with error: {ret:?} ");
                 return false;
             }
         }

--- a/creds/src/structs.rs
+++ b/creds/src/structs.rs
@@ -71,7 +71,7 @@ impl IOLocations {
         match self.public_io_locations.get(key) {
             Some(location) => Ok(*location),
             None => Err(std::io::Error::other(
-                format!("Key {} not found in public_io_locations", key),
+                format!("Key {key} not found in public_io_locations"),
             )),
         }
     }

--- a/creds/src/utils.rs
+++ b/creds/src/utils.rs
@@ -48,7 +48,7 @@ where
 {
     let mut counter = 0;
     loop {
-        let input_iter = format!("{}||{}", input, counter);
+        let input_iter = format!("{input}||{counter}");
         let mut hasher = Sha512::new();
         hasher.update(input_iter);
         let digest = hasher.finalize();
@@ -180,7 +180,7 @@ pub fn read_from_file<T>(path: &str) -> Result<T, SerializationError>
 where
     T: CanonicalDeserialize
 {
-    println!("Reading from file: {}", path);
+    println!("Reading from file: {path}");
     let f = File::open(path).unwrap();
     let buf_reader = BufReader::new(f);
     let state = T::deserialize_uncompressed_unchecked(buf_reader)?;
@@ -232,9 +232,9 @@ mod tests {
     {
         let timer = start_timer!(|| "Time to generate three points");
         for i in 1..4 {
-            let point = hash_to_curve_vartime::<E::G1>(&format!("test string {}", i));
+            let point = hash_to_curve_vartime::<E::G1>(&format!("test string {i}"));
             assert!(point.is_on_curve());
-            println!("point_{} in G1 = {:?}", i, point);
+            println!("point_{i} in G1 = {point:?}");
         }
         end_timer!(timer);
     }

--- a/ecdsa-pop/src/emulated/field_element.rs
+++ b/ecdsa-pop/src/emulated/field_element.rs
@@ -1339,8 +1339,7 @@ mod tests {
                     cs.enforce(
                         || {
                             format!(
-                                "c constant limb {i} equality for condition = {:?}",
-                                condition_bools
+                                "c constant limb {i} equality for condition = {condition_bools:?}"
                             )
                         },
                         |lc| lc + &res_limbs[i].lc(Fp::one()),
@@ -1418,8 +1417,7 @@ mod tests {
                     cs.enforce(
                         || {
                             format!(
-                                "c variable limb {i} equality for condition = {:?}",
-                                condition_bools
+                                "c variable limb {i} equality for condition = {condition_bools:?}"
                             )
                         },
                         |lc| lc + &res_limbs[i].lc(Fp::one()),
@@ -1764,7 +1762,7 @@ mod tests {
             let limb_size = if i == num_limbs - 1 && a.len()%bpl!=0 {a.len()%bpl} else {bpl};
             let limb_bits = &a[i*bpl .. i*bpl + limb_size];
             let limb_bits : Vec<Boolean> = limb_bits.iter().map(|x| Boolean::from(x.clone())).collect();
-            let limb_i = pack_bits(&mut cs.namespace(|| format!("pack limb {}", i)), &limb_bits)?.into();
+            let limb_i = pack_bits(&mut cs.namespace(|| format!("pack limb {i}")), &limb_bits)?.into();
             limbs.push(limb_i);
         }
         
@@ -1794,12 +1792,12 @@ mod tests {
 
         let mut a_bits = vec![];
         for i in 0..a_int.bits() {
-            let bit = AllocatedBit::alloc(&mut cs.namespace(||format!("bit {}", i)), Some(a_int.bit(i))).unwrap();
+            let bit = AllocatedBit::alloc(&mut cs.namespace(||format!("bit {i}")), Some(a_int.bit(i))).unwrap();
             a_bits.push(bit);
         }
         for i in a_int.bits()..128 {
-            let bit = AllocatedBit::alloc(&mut cs.namespace(||format!("bit {}", i)), Some(false)).unwrap();
-            a_bits.push(bit);            
+            let bit = AllocatedBit::alloc(&mut cs.namespace(||format!("bit {i}")), Some(false)).unwrap();
+            a_bits.push(bit);
         }
 
         let a = allocated_bits_to_emulated_fe(&mut cs.namespace(||"a_bits to a"), &a_bits).unwrap();

--- a/ecdsa-pop/src/emulated/util.rs
+++ b/ecdsa-pop/src/emulated/util.rs
@@ -195,7 +195,7 @@ pub fn decompose(
     num_limbs: usize,
 ) -> Result<Vec<BigInt>, SynthesisError> {
     if input.bits() as usize > num_limbs * num_bits_per_limb {
-        eprintln!("Not enough limbs to represent input {:?}", input);
+        eprintln!("Not enough limbs to represent input {input:?}");
         return Err(SynthesisError::Unsatisfiable);
     }
 
@@ -229,7 +229,7 @@ pub fn allocated_num_to_emulated_fe<CS, F1, EFP>(mut cs: CS, a : &AllocatedNum<F
             limb_size
         };
         let limb_bits = &a_bits[i*limb_size .. i*limb_size + this_limb_size];
-        let limb_i = pack_bits(&mut cs.namespace(|| format!("pack limb {}", i)), limb_bits)?.into();
+        let limb_i = pack_bits(&mut cs.namespace(|| format!("pack limb {i}")), limb_bits)?.into();
         limbs.push(limb_i);
     }
 

--- a/ecdsa-pop/src/lib.rs
+++ b/ecdsa-pop/src/lib.rs
@@ -545,7 +545,7 @@ impl ECDSAProof {
     end_timer!(t);
 
     let msg_proof_len = format!("NIZK::proof_compressed_len {:?}", proof_encoded.len());
-    println!("{}", msg_proof_len);
+    println!("{msg_proof_len}");
 
     (R.x, R.y, proof_encoded) // TODO: return errors too
   }
@@ -848,7 +848,7 @@ mod tests {
     end_timer!(t);
 
     let msg_proof_len = format!("NIZK::proof_compressed_len {:?}", proof_encoded.len());
-    println!("{}", msg_proof_len);
+    println!("{msg_proof_len}");
 
     let t = start_timer!(|| "Decompress proof");
     let mut decoder = ZlibDecoder::new(Vec::new());

--- a/ecdsa-pop/src/utils.rs
+++ b/ecdsa-pop/src/utils.rs
@@ -468,7 +468,7 @@ pub fn ff_to_big<FF: ff::PrimeField>(i : &FF) -> BigUint {
 /// converts a hex-encoded string into a BigUint
 pub fn hex_to_big(hex: &str) -> BigUint {
   let hex = if hex.len() % 2 != 0 {
-    &format!("0{}", hex)
+    &format!("0{hex}")
   } else {
     hex
   };

--- a/sample/client/package-lock.json
+++ b/sample/client/package-lock.json
@@ -33,7 +33,7 @@
     },
     "../../creds/pkg": {
       "name": "crescent",
-      "version": "0.5.0",
+      "version": "1.0.0",
       "dev": true
     },
     "node_modules/@eslint-community/eslint-utils": {


### PR DESCRIPTION
A Rust update to 1.88 has introduced a new Clippy error requiring format-strings to contain the variables within the string instead of being passes as separate parameters. For example:
```rust
// this
format!("Missing key: {}", ISO_MDL_NAMESPACE))

// should now be this
format!("Missing key: {ISO_MDL_NAMESPACE}"))
```

> All of the changes in the 17 files are of this form, addressing this specific new Clippy error.
