### PR TITLE
Set Rust compiler version to 1.88.0

### DIFF
--- a/creds/rust-toolchain
+++ b/creds/rust-toolchain
@@ -1,1 +1,2 @@
-stable
+[toolchain]
+channel = "1.88.0"

--- a/forks/halo2curves/src/lib.rs
+++ b/forks/halo2curves/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 mod arithmetic;
 mod curve;
 pub mod ff_ext;

--- a/sample/client_helper/rust-toolchain
+++ b/sample/client_helper/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.88.0"


### PR DESCRIPTION
The project will not build with the latest version of the Rust compiler, due to a problem with an older version of a dependency.

See Issue #148 for details.